### PR TITLE
minor fixes in documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,28 +6,28 @@
 *Table of Contents*
 :CONTENTS:
 - [[#lepton-old-name-proton-fix][Lepton (old name: Proton Fix)]]
-  - [[#introduce][Introduce]]
-  - [[#how-to-install][How to Install?]]
+  - [[#introduction][Introduction]]
+  - [[#installation-guide][Installation Guide]]
   - [[#why-proton][WHY Proton?]]
   - [[#why-not-proton][WHY Not Proton?]]
   - [[#padding-comparisons][Padding Comparisons]]
 :END:
 
 
-** Introduce
-  [[https://wiki.mozilla.org/Firefox/Proton][Proton]] is Firefox's new design. \\
-  And [[https://design.firefox.com/photon/][Photon]] is old design(88 or earlier)
+** Introduction
+  [[https://wiki.mozilla.org/Firefox/Proton][Proton]] is Firefox's new design, starting from Firefox 89. \\
+  [[https://design.firefox.com/photon/][Photon]] is the old design of Firefox which was used until version 88.
 
   Proton's [[#why-proton][overall feel is good]], but there were a few things I [[#why-not-proton][didn't like]] and wanted to improve. \\
   That's why this project was born, and Lepton to denote light theme layer.
 
-  /Disclaimer:/ It works *Firefox 89* above!!
+  /Disclaimer:/ It works *Firefox 89* and above!!
   | *Wiki*      |                               |      |
   | [[https://github.com/black7375/Firefox-UI-Fix/wiki/Screenshots][Screenshots]] | [[https://github.com/black7375/Firefox-UI-Fix/wiki/Compatibility-Issues-Solution][Compatibility Issues Solution]] | [[https://github.com/black7375/Firefox-UI-Fix/wiki/Tips][Tips]] |
 
   [[https://user-images.githubusercontent.com/25581533/119774062-20942280-beb1-11eb-80aa-c18dd52f18d7.png]]
-
-  (Lepton's design)
+ 
+ (Lepton's design :arrow_up:)
 
   - *Icons*
     - Panel
@@ -61,7 +61,7 @@
     - Icons:
       - Size: Fill it up
 
-** How to Install?
+** Installation Guide
 
   1. Download Files
      - Above right's :arrow_down: Code
@@ -83,7 +83,7 @@
 
    [[https://user-images.githubusercontent.com/25581533/119773764-a6639e00-beb0-11eb-8023-498b6293c4b2.png]]
 
-   (Proton's design)
+   (Proton's design :arrow_up:)
 
    - Neatly organized menu
    - Icon beautiful enough to remind you of Edge
@@ -96,7 +96,7 @@
 
    [[https://user-images.githubusercontent.com/25581533/119773812-b5e2e700-beb0-11eb-923c-55ae1a8ca249.png]]
 
-   (Photon's design)
+   (Photon's design :arrow_up:)
 
    - Is it a tab or a button?
    - Where are the menu icons?
@@ -112,4 +112,4 @@
 
   - Photon (Quantum)
   - Proton
-  - Proton Fix
+  - Lepton


### PR DESCRIPTION
There were some unnatural grammar usage in the documentation and the name of this project is incorrectly displayed at the end of it(It's displayed as Proton Fix, which is the old name) . 
I suggest you to change the directory tree of this repo to be easier to install this theme. (What I mean by that is to move the .css files and /icons folder to a new directory called `chrome`.)