### PR TITLE
Fixes #36: wrong icons under More Tools if debugging is disabled

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -816,19 +816,19 @@
   #appmenu-developer-tools-view  .subviewbutton:nth-child(5) {  /* Browser Content Toolbaox -  */
     list-style-image: url(./icons/command-frames.svg);
   }
-  #appmenu-developer-tools-view  .subviewbutton:nth-child(6) {  /* Browser Console */
+  #appmenu-developer-tools-view  .subviewbutton:nth-last-child(5) {  /* Browser Console */
     list-style-image: url(chrome://devtools/skin/images/command-console.svg);
   }
-  #appmenu-developer-tools-view  .subviewbutton:nth-child(7) {  /* Responsive Design Mode */
+  #appmenu-developer-tools-view  .subviewbutton:nth-last-child(4) {  /* Responsive Design Mode */
     list-style-image: url(./icons/command-responsivemode.svg);
   }
-  #appmenu-developer-tools-view  .subviewbutton:nth-child(8) {  /* Eyedropper */
+  #appmenu-developer-tools-view  .subviewbutton:nth-last-child(3) {  /* Eyedropper */
     list-style-image: url(chrome://devtools/skin/images/command-eyedropper.svg);
   }
-  #appmenu-developer-tools-view  .subviewbutton:nth-child(9) {  /* Page Source - Edge file-search.svg */
+  #appmenu-developer-tools-view  .subviewbutton:nth-last-child(2) {  /* Page Source - Edge file-search.svg */
     list-style-image: url(./icons/search-file.svg);
   }
-  #appmenu-developer-tools-view  .subviewbutton:nth-child(10) { /* Extensions for Devel */
+  #appmenu-developer-tools-view  .subviewbutton:nth-last-child(1) { /* Extensions for Devel */
     list-style-image: url(chrome://devtools/skin/images/debugging-addons.svg);
   }
   #appmenu-developer-tools-view .subviewbutton:last-child {


### PR DESCRIPTION
This change makes the icons in the More Tools menu look correct regardless of whether "Enable browser chrome and add-on debugging toolboxes" is disabled. It does this by assigning the latter half of the icons via `nth-last-child()` so that if the 2 lines are absent from the menu, the icons for those positions get overruled by the correct ones. If the two lines _are_ present, their icons are not overruled.

![1622735710](https://user-images.githubusercontent.com/1035411/120674987-f20bde00-c494-11eb-92e5-bd66c84557ef.png)
