### PR TITLE
ref: Exclude unnecessary files from zip export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github export-ignore


### PR DESCRIPTION
With this `.gitattributes` file, the `.github` folder and some other unnecessary files will be excluded from the git zip archive to make the installation cleaner.