### PR TITLE
fix: Fix sharing icon is not aligned

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1020,7 +1020,7 @@
     display: none;
   }
 
-  .tab-icon-image {
+  .tab-icon-image, .tab-sharing-icon-overlay {
     box-sizing: content-box;
     padding: 3px 0;
 


### PR DESCRIPTION
On Windows 10 and Original Lepton, There is a bug on sharing icon, so I fixed and made pull request.
![image](https://user-images.githubusercontent.com/47362439/126465744-65cd5c27-0a1c-45ba-88fc-ddf92410affa.png)
