### PR TITLE
"WHY Not Proton" -> "Why NOT Proton"

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@
   - [[#introduction][Introduction]]
   - [[#installation-guide][Installation Guide]]
   - [[#why-proton][WHY Proton?]]
-  - [[#why-not-proton][WHY Not Proton?]]
+  - [[#why-not-proton][Why NOT Proton?]]
   - [[#padding-comparisons][Padding Comparisons]]
   - [[#faq][FAQ]]
 :END:
@@ -93,7 +93,7 @@
    - Satisfied Rounding
    - Modal window & Scrollbar!!
 
-** WHY Not Proton?
+** Why NOT Proton?
    However, there are also many flaws.
 
    [[https://user-images.githubusercontent.com/25581533/119773812-b5e2e700-beb0-11eb-923c-55ae1a8ca249.png]]


### PR DESCRIPTION
Emphasis on the "not" differentiates it from the "WHY Proton"-heading