### PR TITLE
Show close button on background tab only on hover

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -3308,6 +3308,14 @@
   #tabbrowser-arrowscrollbox:not([overflowing]) .tabbrowser-tab[last-visible-tab] {
     margin-inline-end: 1px !important;
   }
+  
+  /*Only show close buttons on background tabs when hovering with the mouse */
+.tabbrowser-tab:not([selected]):not([pinned]) .tab-close-button {
+  display: none !important;
+}
+.tabbrowser-tab:not([selected]):not([pinned]):hover .tab-close-button {
+  display: -moz-box !important;
+}
 
   /* New tab button - Looks like tab ******************************************/
   #tabs-newtab-button {


### PR DESCRIPTION
**Describe the PR**
This change will  make close button on unselected/background tabs only appear when being hovered by mouse this will enhance the user experience by decluttering the interface.

**Related Issue**
No its just a minute change

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

**Environment (please complete the following information):**
<!-- Check like `- [x]`. -->

 - PR Type
   - [x] `Add:` Add feature or enhanced.
   - [ ] `Fix:` Bug fix or change default values.
   - [ ] `Clean:` Refactoring.
   - [ ] `Doc:` Update docs.
 - Distribution
   - [x] [Original Lepton](https://github.com/black7375/Firefox-UI-Fix)
   - [ ] [Lepton's photon style](https://github.com/black7375/Firefox-UI-Fix/tree/photon-style)
   - [ ] [Lepton's proton style](https://github.com/black7375/Firefox-UI-Fix/tree/proton-style)

**Additional context**
<!-- Add any other context about the commit here. -->
