### PR TITLE
Fix: Unreadable text on Add-on Developer Hub

### DIFF
--- a/userContent.css
+++ b/userContent.css
@@ -543,7 +543,7 @@ video {
     /* Basic */
     .Page-content,
     .SecondaryHero,
-    body,
+    body:not(.developer-hub):not(.statistics),
     main[aria-label="Content"] {
       color: var(--in-content-page-color) !important;
       background: var(--in-content-page-background) !important;
@@ -752,17 +752,33 @@ video {
     }
 
     /* /developers/ */
-    .DevHub-Navigation {
+    .DevHub-Navigation,
+    .DevHub-submit-addon,
+    .DevHub-get-involved,
+    .DevHub-MyAddons > * {
       background: var(--in-content-page-background) !important;
+      color: var(--in-content-page-color) !important;
+    }
+    .DevHub-Footer {
+        background: var(--in-content-box-background) !important;
+        color: var(--in-content-page-color) !important;
     }
     .DevHub-Navigation.scheme-light ul li a,
-    .DevHub-content-copy h2,
-    .content p {
+    .DevHub-Footer-sections-header,
+    .DevHub-Footer-section h4,
+    .DevHub-Footer-section p,
+    .DevHub-content-copy h2 {
       color: var(--in-content-page-color) !important;
     }
     .DevHub-callout-box {
       background: var(--in-content-box-background) !important;
       color: var(--in-content-page-color) !important;
+    }
+    .DevHub-Banner a,
+    .DevHub-Footer a,
+    .DevHub-MyAddons-list a,
+    .DevHub-MyAddons-item-buttons-all {
+      color: var(--in-content-link-color) !important;
     }
   }
 


### PR DESCRIPTION
**Describe the PR**

Fixes unreadable/white text on Add-On Developer Hub website. (Note that dark mode is still not implemented.)

**Related Issue**

Fixes #365 (at least text visibility part).

**Screenshots**

<details>

  ![slika](https://user-images.githubusercontent.com/16626308/164986905-bcb9a96a-9a48-412e-b58c-3c92abfc8335.png)
</details>

<details>

  ![slika](https://user-images.githubusercontent.com/16626308/164986960-7fedc21e-e06b-4525-a3d8-5d1a48c10d0f.png)

</details>

**Environment (please complete the following information):**

 - PR Type
   - [ ] `Add:` Add feature or enhanced.
   - [x] `Fix:` Bug fix or change default values.
   - [ ] `Clean:` Refactoring.
   - [ ] `Doc:` Update docs.
 - Distribution
   - [x] [Original Lepton](https://github.com/black7375/Firefox-UI-Fix)
   - [x] [Lepton's photon style](https://github.com/black7375/Firefox-UI-Fix/tree/photon-style)
   - [x] [Lepton's proton style](https://github.com/black7375/Firefox-UI-Fix/tree/proton-style)
   - (applies to all distributions)
