### PR TITLE
Pinned tab close button at hover

### DIFF
--- a/src/tabbar/_clipped_tab.scss
+++ b/src/tabbar/_clipped_tab.scss
@@ -8,6 +8,9 @@
   @import "clipped_tab/show_close_button_at_hover";
 }
 
+/** Clipped tabs - Show close button at hover on pinned ***********************/
+@import "clipped_tab/show_close_button_at_hover_pinned";
+
 /** Clipped tabs - Always show tab icon ***************************************/
 @include Option("userChrome.tab.always_show_tab_icon") {
   @import "clipped_tab/always_show_tab_icon";

--- a/src/tabbar/_clipped_tab.scss
+++ b/src/tabbar/_clipped_tab.scss
@@ -9,7 +9,14 @@
 }
 
 /** Clipped tabs - Show close button at hover on pinned ***********************/
-@import "clipped_tab/show_close_button_at_hover_pinned";
+@include Option("userChrome.tab.close_button_at_hover_pinned") {
+  @import "clipped_tab/show_close_button_at_hover_pinned";
+}
+
+/** Clipped tabs - Show close button at hover on pinned non-selected ***********/
+@include Option("userChrome.tab.close_button_at_hover_pinned.always") {
+  @import "clipped_tab/show_close_button_at_hover_pinned_always";
+}
 
 /** Clipped tabs - Always show tab icon ***************************************/
 @include Option("userChrome.tab.always_show_tab_icon") {

--- a/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned.scss
+++ b/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned.scss
@@ -1,88 +1,43 @@
-@include Option("userChrome.tab.close_button_at_hover_pinned") {
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] {
-    --pinned-hover-delay: 2s;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-close-button,
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-pending {
-    display: -moz-box !important;
-    visibility: collapse !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-close-button {
-    -moz-box-ordinal-group: 0 !important;
-    transform: translateX(-1px) translateY(-1.5px);
-    visibility: visible !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-icon-stack {
-    width: 16px !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-stack {
-    width: 0px !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-icon-overlay {
-    transform: translateX(0px) translateY(0px);
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-overlay {
-    transform: translateX(-16px) translateY(-2.25px);
-  }
-  
-  /* Animate */
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-close-button {
-    transition: visibility 0.25s var(--animation-easing-function) var(--pinned-hover-delay) !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-pending {
-    transition: visibility 0s var(--pinned-hover-delay) !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-stack {
-    transition: width 0s var(--pinned-hover-delay) !important;
-  }
-  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-overlay {
-    transition: transform 0s var(--pinned-hover-delay) !important;
-  }
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] {
+  --pinned-hover-delay: 2s;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-close-button,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-pending {
+  display: -moz-box !important;
+  visibility: collapse !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-close-button {
+  -moz-box-ordinal-group: 0 !important;
+  transform: translateX(-1px) translateY(-1.5px);
+  visibility: visible !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-icon-stack {
+  width: 16px !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-stack {
+  width: 0px !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-icon-overlay {
+  transform: translateX(0px) translateY(0px);
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-overlay {
+  transform: translateX(-16px) translateY(-2.25px);
+}
 
-  @include Option("userChrome.tab.close_button_at_hover_pinned.always") {
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-close-button,
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-image,
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-throbber,
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-pending {
-      display: -moz-box !important;
-      visibility: collapse !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-close-button {
-      -moz-box-ordinal-group: 0 !important;
-      transform: translateX(-1px) translateY(-1.5px);
-      visibility: visible !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-icon-stack {
-      width: 16px !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-stack {
-      width: 0px !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-icon-overlay {
-      transform: translateX(0px) translateY(0px);
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-overlay {
-      transform: translateX(-16px) translateY(-2.25px);
-    }
-
-    /* Animate */
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-close-button {
-      transition: visibility 0.25s var(--animation-easing-function) var(--pinned-hover-delay) !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-image,
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-throbber,
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-pending {
-      transition: visibility 0s var(--pinned-hover-delay) !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-stack {
-      transition: width 0s var(--pinned-hover-delay) !important;
-    }
-    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-overlay {
-      transition: transform 0s var(--pinned-hover-delay) !important;
-    }
-  }
+/* Animate */
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-close-button {
+  transition: visibility 0.25s var(--animation-easing-function) var(--pinned-hover-delay) !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-pending {
+  transition: visibility 0s var(--pinned-hover-delay) !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-stack {
+  transition: width 0s var(--pinned-hover-delay) !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-overlay {
+  transition: transform 0s var(--pinned-hover-delay) !important;
 }

--- a/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned.scss
+++ b/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned.scss
@@ -1,0 +1,88 @@
+@include Option("userChrome.tab.close_button_at_hover_pinned") {
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] {
+    --pinned-hover-delay: 2s;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-close-button,
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-pending {
+    display: -moz-box !important;
+    visibility: collapse !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-close-button {
+    -moz-box-ordinal-group: 0 !important;
+    transform: translateX(-1px) translateY(-1.5px);
+    visibility: visible !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-icon-stack {
+    width: 16px !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-stack {
+    width: 0px !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-icon-overlay {
+    transform: translateX(0px) translateY(0px);
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-overlay {
+    transform: translateX(-16px) translateY(-2.25px);
+  }
+  
+  /* Animate */
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-close-button {
+    transition: visibility 0.25s var(--animation-easing-function) var(--pinned-hover-delay) !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-pending {
+    transition: visibility 0s var(--pinned-hover-delay) !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-stack {
+    transition: width 0s var(--pinned-hover-delay) !important;
+  }
+  #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-overlay {
+    transition: transform 0s var(--pinned-hover-delay) !important;
+  }
+
+  @include Option("userChrome.tab.close_button_at_hover_pinned.always") {
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-close-button,
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-image,
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-throbber,
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-pending {
+      display: -moz-box !important;
+      visibility: collapse !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-close-button {
+      -moz-box-ordinal-group: 0 !important;
+      transform: translateX(-1px) translateY(-1.5px);
+      visibility: visible !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-icon-stack {
+      width: 16px !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-stack {
+      width: 0px !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-icon-overlay {
+      transform: translateX(0px) translateY(0px);
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-overlay {
+      transform: translateX(-16px) translateY(-2.25px);
+    }
+
+    /* Animate */
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-close-button {
+      transition: visibility 0.25s var(--animation-easing-function) var(--pinned-hover-delay) !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-image,
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-throbber,
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-pending {
+      transition: visibility 0s var(--pinned-hover-delay) !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-stack {
+      transition: width 0s var(--pinned-hover-delay) !important;
+    }
+    #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-overlay {
+      transition: transform 0s var(--pinned-hover-delay) !important;
+    }
+  }
+}

--- a/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned.scss
+++ b/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned.scss
@@ -1,6 +1,7 @@
 #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] {
   --pinned-hover-delay: 2s;
 }
+
 #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected] .tab-close-button,
 #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-icon-image,
 #tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned][visuallyselected]:hover .tab-throbber,

--- a/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned_always.sccs
+++ b/src/tabbar/clipped_tab/_show_close_button_at_hover_pinned_always.sccs
@@ -1,0 +1,44 @@
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] {
+  --pinned-hover-delay: 2s;
+}
+
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-close-button,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-image,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-throbber,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-pending {
+  display: -moz-box !important;
+  visibility: collapse !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-close-button {
+  -moz-box-ordinal-group: 0 !important;
+  transform: translateX(-1px) translateY(-1.5px);
+  visibility: visible !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-icon-stack {
+  width: 16px !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-stack {
+  width: 0px !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned] .tab-icon-overlay {
+  transform: translateX(0px) translateY(0px);
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-overlay {
+  transform: translateX(-16px) translateY(-2.25px);
+}
+
+/* Animate */
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-close-button {
+  transition: visibility 0.25s var(--animation-easing-function) var(--pinned-hover-delay) !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-image,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-throbber,
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-pending {
+  transition: visibility 0s var(--pinned-hover-delay) !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-stack {
+  transition: width 0s var(--pinned-hover-delay) !important;
+}
+#tabbrowser-tabs:not([movingtab]) .tabbrowser-tab[pinned]:hover .tab-icon-overlay {
+  transition: transform 0s var(--pinned-hover-delay) !important;
+}

--- a/user.js
+++ b/user.js
@@ -88,14 +88,16 @@ user_pref("userChrome.tab.bottom_rounded_corner",      true);
 // user_pref("userChrome.urlView.go_button_when_typing",       true);
 // user_pref("userChrome.urlView.always_show_page_actions",    true);
 
-// user_pref("userChrome.tab.on_bottom",                       true);
-// user_pref("userChrome.tab.on_bottom.above_bookmark",        true); // Need on_bottom
-// user_pref("userChrome.tab.on_bottom.menubar_on_top",        true); // Need on_bottom
-// user_pref("userChrome.tab.always_show_tab_icon",            true);
-// user_pref("userChrome.tab.close_button_at_pinned",          true);
-// user_pref("userChrome.tab.close_button_at_hover.always",    true); // Need close_button_at_hover
-// user_pref("userChrome.tab.sound_show_label",                true); // Need remove sound_hide_label
-// user_pref("userChrome.tab.centered_label",                  true);
+// user_pref("userChrome.tab.on_bottom",                             true);
+// user_pref("userChrome.tab.on_bottom.above_bookmark",              true); // Need on_bottom
+// user_pref("userChrome.tab.on_bottom.menubar_on_top",              true); // Need on_bottom
+// user_pref("userChrome.tab.always_show_tab_icon",                  true);
+// user_pref("userChrome.tab.close_button_at_pinned",                true);
+// user_pref("userChrome.tab.close_button_at_hover_pinned",          true);
+// user_pref("userChrome.tab.close_button_at_hover_pinned.always",   true);
+// user_pref("userChrome.tab.close_button_at_hover.always",          true); // Need close_button_at_hover
+// user_pref("userChrome.tab.sound_show_label",                      true); // Need remove sound_hide_label
+// user_pref("userChrome.tab.centered_label",                        true);
 
 // user_pref("userChrome.panel.remove_strip",                  true);
 // user_pref("userChrome.panel.full_width_separator",          true);


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->
Currently in https://github.com/black7375/Firefox-UI-Fix/blob/master/src/tabbar/selected_tab/_pinned_close_button.scss
the close button is as big as the tab icon and is display only when the tab is selected, doesn't matter if it is hovered or not.
However I would like to only show the close button of the pinned tabs on hover:
I use the following code, maybe you can do something with it.
You can choose between selected and hovered and always hovered

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
No issue but discussion https://github.com/black7375/Firefox-UI-Fix/discussions/367#discussioncomment-2635679

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

**Environment (please complete the following information):**
<!-- Check like `- [x]`. -->

 - PR Type
   - [x] `Add:` Add feature or enhanced.
   - [ ] `Fix:` Bug fix or change default values.
   - [ ] `Clean:` Refactoring.
   - [ ] `Doc:` Update docs.
 - Distribution
   - [x] [Original Lepton](https://github.com/black7375/Firefox-UI-Fix)
   - [ ] [Lepton's photon style](https://github.com/black7375/Firefox-UI-Fix/tree/photon-style)
   - [x] [Lepton's proton style](https://github.com/black7375/Firefox-UI-Fix/tree/proton-style)

**Additional context**
<!-- Add any other context about the commit here. -->
