### PR TITLE
Allow squaring of additional findbar buttons

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -3226,7 +3226,8 @@
     /* Original: 4px */
   }
 
-  button {
+  button,
+  findbar toolbarbutton {
     border-radius: 0 !important;
   }
 }

--- a/src/rounding/_square.scss
+++ b/src/rounding/_square.scss
@@ -7,7 +7,9 @@
   :root {
     --toolbarbutton-border-radius: 0 !important;  /* Original: 4px */
   }
-  button {
+
+  button,
+  findbar toolbarbutton {
     border-radius: 0 !important;
   }
 }


### PR DESCRIPTION
**Describe the PR**
Allow squaring of next, previous and close findbar buttons, as I do not believe these can be squared currently.

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->
<img width="318" alt="Screenshot 2022-10-24 at 12 14 33" src="https://user-images.githubusercontent.com/47503375/197515249-a4e4430d-f998-4951-a05a-c2c994414f8a.png">


**Environment (please complete the following information):**
<!-- Check like `- [x]`. -->

Tested on MacOS 12.3.1 - Waterfox G5.0.1.

 - PR Type
   - [x] `Add:` Add feature or enhanced.
   - [ ] `Fix:` Bug fix or change default values.
   - [ ] `Clean:` Refactoring.
   - [ ] `Doc:` Update docs.
 - Distribution
   - [x] [Original Lepton](https://github.com/black7375/Firefox-UI-Fix)
   - [ ] [Lepton's photon style](https://github.com/black7375/Firefox-UI-Fix/tree/photon-style)
   - [ ] [Lepton's proton style](https://github.com/black7375/Firefox-UI-Fix/tree/proton-style)

**Additional context**
<!-- Add any other context about the commit here. -->
