### PR TITLE
Add: FFHome - Add the ability to hide Firefox's logo

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -115,6 +115,10 @@ W: https://github.com/Nyubis
 N: roland-rollo
 W: https://github.com/roland-rollo
 
+N: ryenyuku
+E: teamworks1732@gmail.com
+W: https://github.com/ryenyuku
+
 N: SanderTheDragon
 E: sanderthedragon@zoho.com
 W: https://gitlab.com/SanderTheDragon

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -443,7 +443,7 @@
     }
   }
   /** Activity Stream - Hide Firefox's logo ***********************************/
-  @supports -moz-bool-pref("userContent.newTab.hide_logo") {
+  @supports -moz-bool-pref("userContent.newTab.hidden_logo") {
     .logo-and-wordmark {
       display: none !important;
     }

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -442,6 +442,15 @@
       fill: var(--newtab-icon-secondary-color) !important;
     }
   }
+  /** Activity Stream - Hide Firefox's logo ***********************************/
+  @supports -moz-bool-pref("userContent.newTab.hide_logo") {
+    .logo-and-wordmark {
+      display: none !important;
+    }
+    .outer-wrapper:not(.fixed-search) .search-wrapper {
+      padding-top: 0 !important;
+    }
+  }
 }
 /** Error Page - Restore illustrations ****************************************/
 @supports -moz-bool-pref("userContent.page.illustration") {

--- a/src/contents/_activity_stream.scss
+++ b/src/contents/_activity_stream.scss
@@ -193,4 +193,14 @@
       }
     }
   }
+
+  /** Activity Stream - Hide Firefox's logo ***********************************/
+  @include Option("userContent.newTab.hidden_logo") {
+    .logo-and-wordmark {
+      display: none !important;
+    }
+    .outer-wrapper:not(.fixed-search) .search-wrapper {
+      padding-top: 0 !important;
+    }
+  }
 }

--- a/user.js
+++ b/user.js
@@ -158,7 +158,7 @@ user_pref("userChrome.rounding.square_tab",           false);
 // -- User Content -------------------------------------------------------------
 // user_pref("userContent.player.ui.twoline",                  true);
 
-// user_pref("userContent.newTab.hide_logo",                   true);
+// user_pref("userContent.newTab.hidden_logo",                 true);
 
 // user_pref("userContent.page.proton_color.dark_blue_accent", true);
 // user_pref("userContent.page.proton_color.system_accent",    true);

--- a/user.js
+++ b/user.js
@@ -158,6 +158,8 @@ user_pref("userChrome.rounding.square_tab",           false);
 // -- User Content -------------------------------------------------------------
 // user_pref("userContent.player.ui.twoline",                  true);
 
+// user_pref("userContent.newTab.hide_logo",                   true);
+
 // user_pref("userContent.page.proton_color.dark_blue_accent", true);
 // user_pref("userContent.page.proton_color.system_accent",    true);
 // user_pref("userContent.page.monospace",                     true);


### PR DESCRIPTION
**Describe the PR**
Add the ability to hide Firefox's logo in Firefox Home (e.g. about:home and about:newtab)

**Screenshots**
![Screenshot from 2022-12-04 17-48-35](https://user-images.githubusercontent.com/59136093/205486512-ef95539c-ed99-4c01-a21e-ee3e29948732.png)

**Environment (please complete the following information):**

 - PR Type
   - [x] `Add:` Add feature or enhanced.
   - [ ] `Fix:` Bug fix or change default values.
   - [ ] `Clean:` Refactoring.
   - [ ] `Doc:` Update docs.
 - Distribution
   - [x] [Original Lepton](https://github.com/black7375/Firefox-UI-Fix)
   - [ ] [Lepton's photon style](https://github.com/black7375/Firefox-UI-Fix/tree/photon-style)
   - [ ] [Lepton's proton style](https://github.com/black7375/Firefox-UI-Fix/tree/proton-style)