### PR TITLE
Fix: Activity Stream - Enable Hover Highlights on the New Fake Searchbar

### DIFF
--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -343,7 +343,7 @@
       }
       @supports -moz-bool-pref("userContent.page.field_border") {
         .search-wrapper .search-inner-wrapper:hover input,
-        .search-inner-wrapper:hover button {
+        .search-inner-wrapper:hover .search-handoff-button {
           border-color: var(--newtab-primary-action-background) !important;
           transition: border-color 0.5s var(--animation-easing-function);
         }

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -342,7 +342,8 @@
         transition: border-color 0.5s var(--animation-easing-function), box-shadow 1s var(--animation-easing-function);
       }
       @supports -moz-bool-pref("userContent.page.field_border") {
-        .search-wrapper .search-inner-wrapper:hover input {
+        .search-wrapper .search-inner-wrapper:hover input,
+        .search-inner-wrapper:hover button {
           border-color: var(--newtab-primary-action-background) !important;
           transition: border-color 0.5s var(--animation-easing-function);
         }

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -333,17 +333,24 @@
         transition: background 0.5s var(--animation-easing-function);
       }
       /* Search Bar */
-      .search-inner-wrapper input {
+      .search-wrapper .search-inner-wrapper > input,
+      .search-wrapper .search-inner-wrapper > .search-handoff-button {
         transition: 1s var(--animation-easing-function);
         transition-property: border-color, box-shadow;
       }
-      .search-wrapper .search-inner-wrapper:active input,
-      .search-wrapper input:focus {
+      .search-wrapper
+        .search-inner-wrapper:active
+        > input
+        .search-wrapper
+        .search-inner-wrapper:active
+        > .search-handoff-button,
+      .search-wrapper .search-inner-wrapper > input:focus,
+      .search-wrapper .search-inner-wrapper > .search-handoff-button:focus {
         transition: border-color 0.5s var(--animation-easing-function), box-shadow 1s var(--animation-easing-function);
       }
       @supports -moz-bool-pref("userContent.page.field_border") {
-        .search-wrapper .search-inner-wrapper:hover input,
-        .search-inner-wrapper:hover .search-handoff-button {
+        .search-wrapper .search-inner-wrapper:hover > input,
+        .search-wrapper .search-inner-wrapper:hover > .search-handoff-button {
           border-color: var(--newtab-primary-action-background) !important;
           transition: border-color 0.5s var(--animation-easing-function);
         }

--- a/src/contents/_activity_stream.scss
+++ b/src/contents/_activity_stream.scss
@@ -64,19 +64,32 @@
       }
 
       /* Search Bar */
-      .search-inner-wrapper input {
-        transition: 1s var(--animation-easing-function);
-        transition-property: border-color, box-shadow;
-      }
-      .search-wrapper .search-inner-wrapper:active input,
-      .search-wrapper input:focus {
-        transition: border-color 0.5s var(--animation-easing-function), box-shadow 1s var(--animation-easing-function);
-      }
-      @include Option("userContent.page.field_border") {
-        .search-wrapper .search-inner-wrapper:hover input,
-        .search-inner-wrapper:hover .search-handoff-button {
-          border-color: var(--newtab-primary-action-background) !important;
-          transition: border-color 0.5s var(--animation-easing-function);
+      .search-wrapper .search-inner-wrapper {
+        // When `browser.newtabpage.activity-stream.improvesearch.handoffToAwesomebar`
+        // input(#newtab-search-text): false
+        // .search-handoff-button: true
+        $_activityStreamSearchbar: "> input, > .search-handoff-button";
+        $_activeSearchbar: selector.nest(":active", $_activityStreamSearchbar);
+        $_activeSearchbarResult: ();
+        @each $searchbarSelctor in $_activeSearchbar {
+          $_activeSearchbarResult: append($_activeSearchbarResult, "&" + $searchbarSelctor);
+        }
+
+        #{$_activityStreamSearchbar} {
+          transition: 1s var(--animation-easing-function);
+          transition-property: border-color, box-shadow;
+        }
+        #{$_activeSearchbarResult},
+        #{selector.append($_activityStreamSearchbar, ":focus")} {
+          transition: border-color 0.5s var(--animation-easing-function), box-shadow 1s var(--animation-easing-function);
+        }
+        @include Option("userContent.page.field_border") {
+          &:hover {
+            #{$_activityStreamSearchbar} {
+              border-color: var(--newtab-primary-action-background) !important;
+              transition: border-color 0.5s var(--animation-easing-function);
+            }
+          }
         }
       }
     }

--- a/src/contents/_activity_stream.scss
+++ b/src/contents/_activity_stream.scss
@@ -74,7 +74,7 @@
       }
       @include Option("userContent.page.field_border") {
         .search-wrapper .search-inner-wrapper:hover input,
-        .search-inner-wrapper:hover button {
+        .search-inner-wrapper:hover .search-handoff-button {
           border-color: var(--newtab-primary-action-background) !important;
           transition: border-color 0.5s var(--animation-easing-function);
         }

--- a/src/contents/_activity_stream.scss
+++ b/src/contents/_activity_stream.scss
@@ -73,7 +73,8 @@
         transition: border-color 0.5s var(--animation-easing-function), box-shadow 1s var(--animation-easing-function);
       }
       @include Option("userContent.page.field_border") {
-        .search-wrapper .search-inner-wrapper:hover input {
+        .search-wrapper .search-inner-wrapper:hover input,
+        .search-inner-wrapper:hover button {
           border-color: var(--newtab-primary-action-background) !important;
           transition: border-color 0.5s var(--animation-easing-function);
         }


### PR DESCRIPTION
**Describe the PR**
The child component of `search-inner-wrapper` div is a button in the new searchbar (instead of the input textfield), so this PR just add a small change to make highlight works on both old and new searchbar.

**PR Type**

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Screenshots**
Before
![Screenshot_20221217_191418](https://user-images.githubusercontent.com/59136093/208242182-52ff5877-2d02-47af-bcad-c9448666878e.png)
After
![Screenshot_20221217_191311](https://user-images.githubusercontent.com/59136093/208242196-f4045712-538e-43e3-89df-e45aba6d1edf.png)
