### PR TITLE
Fix: Rounding - New migration wizard, firefox view, clear history

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -3199,6 +3199,11 @@
     border-radius: 0 !important;
   }
 }
+@supports -moz-bool-pref("userChrome.rounding.square_infobox") {
+  #sanitizeEverythingWarningBox {
+    border-radius: 0 !important;
+  }
+}
 @supports -moz-bool-pref("userChrome.rounding.square_toolbar") {
   :root {
     --uc-rounding-toolbar: 0;

--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -3174,11 +3174,6 @@
     --tab-border-radius: var(--toolbarbutton-border-radius);
   }
 }
-@supports -moz-bool-pref("userChrome.rounding.square_dialog") {
-  .dialogBox {
-    border-radius: 0 !important;
-  }
-}
 @supports -moz-bool-pref("userChrome.rounding.square_panel") {
   :root {
     --arrowpanel-border-radius: 0 !important;
@@ -3242,6 +3237,12 @@
 @supports -moz-bool-pref("userChrome.rounding.square_checklabel") {
   input[type="checkbox"],
   .checkbox-check {
+    border-radius: 0 !important;
+  }
+}
+@supports -moz-bool-pref("userChrome.rounding.square_dialog") {
+  dialog,
+  .dialogBox {
     border-radius: 0 !important;
   }
 }

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -2935,6 +2935,15 @@
       border-radius: 0 !important;
     }
   }
+  @-moz-document url-prefix("about:firefoxview") {
+    .card,
+    .card::before,
+    .empty-container,
+    .synced-tab-a,
+    .synced-tab-li-placeholder {
+      border-radius: 0 !important;
+    }
+  }
 }
 @-moz-document url-prefix("about:"), regexp(".*.pdf$") {
   @supports -moz-bool-pref("userChrome.rounding.square_dialog") {

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -2834,18 +2834,8 @@
   }
 }
 @supports -moz-bool-pref("userChrome.rounding.square_dialog") {
-  @-moz-document url-prefix("about:") {
-    .dialogBox {
-      border-radius: 0 !important;
-    }
-  }
   @-moz-document url("about:home"), url("about:newtab") {
     .modal {
-      border-radius: 0 !important;
-    }
-  }
-  @-moz-document regexp(".*.pdf$") {
-    dialog {
       border-radius: 0 !important;
     }
   }
@@ -2941,6 +2931,14 @@
   }
   @-moz-document url-prefix("about:debugging") {
     .message {
+      border-radius: 0 !important;
+    }
+  }
+}
+@-moz-document url-prefix("about:"), regexp(".*.pdf$") {
+  @supports -moz-bool-pref("userChrome.rounding.square_dialog") {
+    dialog,
+    .dialogBox {
       border-radius: 0 !important;
     }
   }

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -2887,6 +2887,7 @@
 @supports -moz-bool-pref("userChrome.rounding.square_menupopup") {
   @-moz-document url-prefix("about:"), url-prefix("chrome://")
   {
+    panel,
     menupopup {
       --panel-border-radius: 0 !important;
     }

--- a/src/contents/_rounding.scss
+++ b/src/contents/_rounding.scss
@@ -49,20 +49,8 @@
 }
 
 @include Option("userChrome.rounding.square_dialog") {
-  @include moz-document(url-prefix "about:") {
-    .dialogBox {
-      border-radius: 0 !important;
-    }
-  }
-
   @include moz-document(url "about:home", url "about:newtab") {
     .modal {
-      border-radius: 0 !important;
-    }
-  }
-
-  @include moz-document(regexp ".*\.pdf$") {
-    dialog {
       border-radius: 0 !important;
     }
   }

--- a/src/contents/_rounding.scss
+++ b/src/contents/_rounding.scss
@@ -113,6 +113,7 @@
 
 @include Option("userChrome.rounding.square_menupopup") {
   @include moz-document(url-prefix "about:", url-prefix "chrome://") {
+    panel,
     menupopup {
       --panel-border-radius: 0 !important;
     }

--- a/src/contents/_rounding.scss
+++ b/src/contents/_rounding.scss
@@ -169,4 +169,14 @@
       border-radius: 0 !important;
     }
   }
+
+  @include moz-document(url-prefix "about:firefoxview") {
+    .card,
+    .card::before, // .zap-card border
+    .empty-container,
+    .synced-tab-a,
+    .synced-tab-li-placeholder {
+      border-radius: 0 !important;
+    }
+  }
 }

--- a/src/leptonContent.scss
+++ b/src/leptonContent.scss
@@ -39,6 +39,10 @@
 /** Rounding ******************************************************************/
 @import "contents/rounding";
 
+@include moz-document(url-prefix "about:", regexp ".*\.pdf$") {
+  @import "rounding/dialog";
+}
+
 // Put here to include library as a tab
 @include moz-document(url "chrome://browser/content/places/places.xhtml") {
   @import "rounding/library";

--- a/src/rounding/_dialog.scss
+++ b/src/rounding/_dialog.scss
@@ -1,0 +1,5 @@
+@include Option("userChrome.rounding.square_dialog") {
+  dialog, .dialogBox {
+    border-radius: 0 !important;
+  }
+}

--- a/src/rounding/_index.scss
+++ b/src/rounding/_index.scss
@@ -1,5 +1,6 @@
 /** Rounding ******************************************************************/
 @import "square";
+@import "dialog";
 @import "library";
 
 /*

--- a/src/rounding/_square.scss
+++ b/src/rounding/_square.scss
@@ -38,12 +38,6 @@
   }
 }
 
-@include Option("userChrome.rounding.square_dialog") {
-  .dialogBox {
-    border-radius: 0 !important;
-  }
-}
-
 @include Option("userChrome.rounding.square_panel") {
   :root {
     --arrowpanel-border-radius: 0 !important;

--- a/src/rounding/_square.scss
+++ b/src/rounding/_square.scss
@@ -65,6 +65,12 @@
   }
 }
 
+@include Option("userChrome.rounding.square_infobox") {
+  #sanitizeEverythingWarningBox {
+    border-radius: 0 !important;
+  }
+}
+
 @include Option("userChrome.rounding.square_toolbar") {
   :root {
     --uc-rounding-toolbar: 0;


### PR DESCRIPTION
**Describe the PR**
Add rounding support for the new migration wizard and firefox view infoboxes, fix the clear history infobox not working if summoned from the menu bar

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
#645
