### PR TITLE
Add: Padding - Unified extensions panel with compact mode

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -3936,6 +3936,9 @@
   .unified-extensions-item-menu-button.subviewbutton {
     padding: 8px !important; /* Original: var(--arrowpanel-menuitem-padding-inline) */
   }
+  :root[uidensity="compact"] :is(.unified-extensions-item, .unified-extensions-item-action-button) {
+    padding-block: 0 !important;
+  }
 }
 @supports -moz-bool-pref("userChrome.padding.panel_header") {
   .panel-header {

--- a/src/padding/_panel.scss
+++ b/src/padding/_panel.scss
@@ -30,11 +30,18 @@
   }
 }
 
-// #603
-.unified-extensions-item-menu-button.subviewbutton {
-  padding: 8px !important; /* Original: var(--arrowpanel-menuitem-padding-inline) */
+.unified-extensions-item {
+  // #603
+  &-menu-button.subviewbutton {
+    padding: 8px !important; /* Original: var(--arrowpanel-menuitem-padding-inline) */
+  }
+  // Or
+  // toolbaritem.unified-extensions-item[unified-extensions="true"] .unified-extensions-item-menu-button.subviewbutton {
+  //   padding: var(--arrowpanel-menuitem-padding-inline) !important;
+  // }
+
+  // #711
+  :root[uidensity="compact"] :is(&, &-action-button) {
+    padding-block: 0 !important;
+  }
 }
-// Or
-// toolbaritem.unified-extensions-item[unified-extensions="true"] .unified-extensions-item-menu-button.subviewbutton {
-//   padding: var(--arrowpanel-menuitem-padding-inline) !important;
-// }


### PR DESCRIPTION
**Describe the PR**
add compact mode support for the unified extensions panel

**PR Type**
<!-- Check like `- [x]`. -->

- [x] `Add:` Add feature or enhanced.
- [ ] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
#711

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->
before:
![before](https://github.com/black7375/Firefox-UI-Fix/assets/58827198/d25f1d9a-64fa-47b3-92c2-47b9a4e6cf0b)
after:
![after](https://github.com/black7375/Firefox-UI-Fix/assets/58827198/78eedb9d-5adf-4f8a-a8fa-38741a265fcf)
