### PR TITLE
Fix: folder icons in 'Open Profile Directory' in Floorp browser's application menu

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -13016,7 +13016,7 @@
       list-style-image: url("../icons/refresh-cw.svg");
     }
     #openprofiledir {
-      list-style-image: url("../icons//folder.svg");
+      list-style-image: url("../icons/folder.svg");
     }
   }
   @supports -moz-bool-pref("userChrome.icon.menu") {

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -13626,7 +13626,7 @@
       list-style-image: url("../icons/refresh-cw.svg");
     }
     #openprofiledir {
-      list-style-image: url("../icons//folder.svg");
+      list-style-image: url("../icons/folder.svg");
     }
   }
   @supports -moz-bool-pref("userChrome.icon.menu") {

--- a/src/icons/fork_browsers/_floorp.scss
+++ b/src/icons/fork_browsers/_floorp.scss
@@ -4,7 +4,7 @@
   }
 
   #openprofiledir {
-    list-style-image: url("../icons//folder.svg");
+    list-style-image: url("../icons/folder.svg");
   }
 }
 @include Option("userChrome.icon.menu") {


### PR DESCRIPTION
**Describe the PR**
Fixed folder icons not showing up in 'Open Profile Directory' in Floorp browser's application menu.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Screenshots**
Current
![スクリーンショット 2023-08-26 155225](https://github.com/black7375/Firefox-UI-Fix/assets/61068665/25006dfe-3404-4f07-83bb-731943358ce2)

Expected behavior
![スクリーンショット 2023-08-26 155113](https://github.com/black7375/Firefox-UI-Fix/assets/61068665/9df5c3b8-109c-455f-94b8-d31dce06fd8a)

**Additional context**
I'm an amateur, so I may have missed some points to fix.
