### PR TITLE
Fix double separators when removing Set as Desktop Background menu item

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -16,6 +16,7 @@
  * #context-sendimage,
  * #context-sendvideo,
  * #context-sendaudio,
+ * #context-sep-setbackground,
  * #context-setDesktopBackground {
  *   display: none !important;
  * }


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->
Fix double separators [#764](https://github.com/black7375/Firefox-UI-Fix/issues/764)
**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->
![29-08-23_09-35_file-36](https://github.com/black7375/Firefox-UI-Fix/assets/49761211/7efb2309-c183-4add-9cfc-af73acf8354d)


**Additional context**
<!-- Add any other context about the commit here. -->
