### PR TITLE
Fix: Compatibility - Icon fill color #791

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -58,13 +58,6 @@
   #allTabsMenu-allTabsView .subviewbutton.subviewbutton-nav:not([shortcut]) {
     padding-inline-end: var(--arrowpanel-menuitem-padding-inline) !important;
   }
-  /*= Icon Fill Color ==========================================================*/
-  :root:-moz-lwtheme {
-    /* Auto create --lwt-toolbarbutton-icon-fill-attention, fix for nightly default theme
-         Default Color: rgb(0,97,224) -> rgb(0, 120, 215) for more light
-       */
-    --lwt-toolbarbutton-icon-fill-attention: var(--button-primary-bgcolor, rgb(0, 120, 215));
-  }
   /*= First visible tab margin at maximized #332 ===============================*/
   :root[tabsintitlebar="true"][sizemode="maximized"] #TabsToolbar {
     margin-left: -1px;

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -58,13 +58,6 @@
   #allTabsMenu-allTabsView .subviewbutton.subviewbutton-nav:not([shortcut]) {
     padding-inline-end: var(--arrowpanel-menuitem-padding-inline) !important;
   }
-  /*= Icon Fill Color ==========================================================*/
-  :root:-moz-lwtheme {
-    /* Auto create --lwt-toolbarbutton-icon-fill-attention, fix for nightly default theme
-         Default Color: rgb(0,97,224) -> rgb(0, 120, 215) for more light
-       */
-    --lwt-toolbarbutton-icon-fill-attention: var(--button-primary-bgcolor, rgb(0, 120, 215));
-  }
   /*= First visible tab margin at maximized #332 ===============================*/
   :root[tabsintitlebar="true"][sizemode="maximized"] #TabsToolbar {
     margin-left: -1px;

--- a/src/compatibility/_theme.scss
+++ b/src/compatibility/_theme.scss
@@ -34,14 +34,6 @@ menu.subviewbutton {
   padding-inline-end: var(--arrowpanel-menuitem-padding-inline) !important; // #717
 }
 
-/*= Icon Fill Color ==========================================================*/
-:root:-moz-lwtheme {
-  /* Auto create --lwt-toolbarbutton-icon-fill-attention, fix for nightly default theme
-       Default Color: rgb(0,97,224) -> rgb(0, 120, 215) for more light
-     */
-  --lwt-toolbarbutton-icon-fill-attention: var(--button-primary-bgcolor, rgb(0, 120, 215));
-}
-
 /*= First visible tab margin at maximized #332 ===============================*/
 :root[tabsintitlebar="true"][sizemode="maximized"] #TabsToolbar {
   margin-left: -1px;


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->


My OS theme is `Breeze / Adwaita`, and it looks like this:

![image](https://github.com/black7375/Firefox-UI-Fix/assets/25581533/dc468cae-e086-4c4b-968e-b930e6be2268)
(It seems to be working relatively well)

`AccentColor` is currently being applied.
![image](https://github.com/black7375/Firefox-UI-Fix/assets/25581533/08425c2d-c98e-4763-8e52-23d966bf6f92)
![image](https://github.com/black7375/Firefox-UI-Fix/assets/25581533/aac27e53-81cd-4840-bc1c-86fa3dcddce3)
![image](https://github.com/black7375/Firefox-UI-Fix/assets/25581533/de7390aa-815a-47d6-8f2a-f4882611b5f6)

```css
#star-button[sttared] {
  fill-opacity: 1;
  fill: var(--tolbarbutton-icon-fill-attention);
}

:root:-moz-lwtheme {
  --download-progress-fill-color: var(--lwt-toolbarbutton-icon-fill-attention, light-dark(rgb(0, 97, 224), rgb(0, 221, 255)));
}
:root:-moz-lwtheme {
  --toolbarbutton-icon-fill-attention: var(--lwt-toolbarbutton-icon-fill-attention, light-dark(rgb(0, 97, 224), rgb(0, 221, 255)));
}

root:-moz-lwtheme {
  --lwt-toolbarbutton-icon-fill-attention: var(--button-primary-bgcolor, rgb(0, 120, 215));
}
```

We can resolve the issue by removing the code that was causing the compatibility issue.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

#791

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

**Additional context**
<!-- Add any other context about the commit here. -->
