### PR TITLE
Fix: Proton - MacOS page info icons cut off #780

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -2901,6 +2901,11 @@
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }
+    @supports -moz-bool-pref("layout.css.osx-font-smoothing.enabled") {
+      #viewGroup > radio {
+        height: auto !important;
+      }
+    }
     #generalTab {
       --viewgroup-image: url(chrome://global/skin/icons/page-portrait.svg);
     }

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -3218,6 +3218,11 @@
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }
+    @supports -moz-bool-pref("layout.css.osx-font-smoothing.enabled") {
+      #viewGroup > radio {
+        height: auto !important;
+      }
+    }
     #generalTab {
       --viewgroup-image: url(chrome://global/skin/icons/page-portrait.svg);
     }

--- a/src/theme/proton_chrome/_page_info.scss
+++ b/src/theme/proton_chrome/_page_info.scss
@@ -33,6 +33,10 @@
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }
+
+    @include OS($mac) {
+      height: auto !important;
+    }
   }
   #generalTab {
     --viewgroup-image: url(chrome://global/skin/icons/page-portrait.svg);


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->

Calculate page info's tab height.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

#780

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

- before
![image](https://github.com/black7375/Firefox-UI-Fix/assets/25581533/d323e086-accc-481b-93ae-a73bc5d2a4f0)

- after
![image](https://github.com/black7375/Firefox-UI-Fix/assets/25581533/0ab98b2e-786c-4ea6-baf9-380430a4125f)

**Additional context**
<!-- Add any other context about the commit here. -->
