### PR TITLE
fix: Compatibility with multirow-tab

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -4041,13 +4041,13 @@
   }
   @supports not -moz-bool-pref("userChrome.tab.photon_like_padding") {
     @supports -moz-bool-pref("userChrome.tab.lepton_like_padding") {
-      .tabbrowser-tab[pinned] {
+      #TabsToolbar:not([multibar]) .tabbrowser-tab[pinned] {
         padding-inline: 1px !important;
       }
-      .tabbrowser-tab:not([pinned]):not(:first-of-type) {
+      #TabsToolbar:not([multibar]) .tabbrowser-tab:not([pinned]):not(:first-of-type) {
         margin-inline: -1px !important;
       }
-      .tabbrowser-tab:not([pinned]):first-of-type {
+      #TabsToolbar:not([multibar]) .tabbrowser-tab:not([pinned]):first-of-type {
         margin-inline-end: -1px !important;
       }
     }

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -4361,13 +4361,13 @@
   }
   @supports not -moz-bool-pref("userChrome.tab.photon_like_padding") {
     @supports -moz-bool-pref("userChrome.tab.lepton_like_padding") {
-      .tabbrowser-tab[pinned] {
+      #TabsToolbar:not([multibar]) .tabbrowser-tab[pinned] {
         padding-inline: 1px !important;
       }
-      .tabbrowser-tab:not([pinned]):not(:first-of-type) {
+      #TabsToolbar:not([multibar]) .tabbrowser-tab:not([pinned]):not(:first-of-type) {
         margin-inline: -1px !important;
       }
-      .tabbrowser-tab:not([pinned]):first-of-type {
+      #TabsToolbar:not([multibar]) .tabbrowser-tab:not([pinned]):first-of-type {
         margin-inline-end: -1px !important;
       }
     }

--- a/src/padding/_tabbar_width.scss
+++ b/src/padding/_tabbar_width.scss
@@ -101,7 +101,7 @@
 }
 @include NotOption("userChrome.tab.photon_like_padding") {
   @include Option("userChrome.tab.lepton_like_padding") {
-    .tabbrowser-tab {
+    #TabsToolbar:not([multibar]) .tabbrowser-tab {
       // Original: padding-inline 2px, margin-inline 0px #643
       &[pinned] {
         padding-inline: 1px !important;


### PR DESCRIPTION
Floorp Injection. The old code causes breaking Floorp's multirow-tabs (Paxmod)

**Describe the PR**
<!-- A clear and concise description of what the PR is. -->

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

#777

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

https://github.com/black7375/Firefox-UI-Fix/assets/73892113/2c14bad3-76b7-49f8-a88b-78ba5080e685

**Additional context**

The issue should not be closed immediately after the merge, as there may be other code causing this problem. I will carry on research this issue.

<!-- Add any other context about the commit here. -->
