### PR TITLE
Fix: Tabbar - Container opacity when not pinned

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -8476,7 +8476,10 @@
       }
     }
     @supports not -moz-bool-pref("userChrome.tab.container.on_top") {
-      .tab-content[titlechanged]::before {
+      .tabbrowser-tab:is([image], [pinned])[usercontextid]
+        > .tab-stack
+        > .tab-content[attention]:not([selected])::before,
+      .tabbrowser-tab[usercontextid] > .tab-stack > .tab-content[pinned][titlechanged]:not([selected])::before {
         opacity: 0;
       }
       /* Pinned Tab - Titlechanged Indicator override */
@@ -22793,7 +22796,8 @@
   }
 }
 @media (-moz-bool-pref: "userChrome.tab.container") and (not (-moz-bool-pref: "userChrome.tabbar.as_titlebar")) and (not (-moz-bool-pref: "userChrome.tab.container.on_top")) {
-  .tab-content[titlechanged]::before {
+  .tabbrowser-tab:is([image], [pinned])[usercontextid] > .tab-stack > .tab-content[attention]:not([selected])::before,
+  .tabbrowser-tab[usercontextid] > .tab-stack > .tab-content[pinned][titlechanged]:not([selected])::before {
     opacity: 0;
   }
   /* Pinned Tab - Titlechanged Indicator override */

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -8906,7 +8906,10 @@
       }
     }
     @supports not -moz-bool-pref("userChrome.tab.container.on_top") {
-      .tab-content[titlechanged]::before {
+      .tabbrowser-tab:is([image], [pinned])[usercontextid]
+        > .tab-stack
+        > .tab-content[attention]:not([selected])::before,
+      .tabbrowser-tab[usercontextid] > .tab-stack > .tab-content[pinned][titlechanged]:not([selected])::before {
         opacity: 0;
       }
       /* Pinned Tab - Titlechanged Indicator override */

--- a/src/tab/_container_tab.scss
+++ b/src/tab/_container_tab.scss
@@ -71,7 +71,8 @@
 }
 
 @include NotOption("userChrome.tab.container.on_top") {
-  .tab-content[titlechanged]::before {
+  .tabbrowser-tab:is([image], [pinned])[usercontextid] > .tab-stack > .tab-content[attention]:not([selected])::before,
+  .tabbrowser-tab[usercontextid] > .tab-stack > .tab-content[pinned][titlechanged]:not([selected])::before {
     opacity: 0;
   }
 


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->

Currently container line disappears when the tab title is changed, even if the tab is not pinned. This PR fixes that.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

**Additional context**
<!-- Add any other context about the commit here. -->
