### PR TITLE
Fix: Tab - Supernova Contextline Position/Animation in container-tabs

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -7658,7 +7658,7 @@
       > .tab-stack
       > .tab-background
       > .tab-context-line::before {
-      background-color: rgba(0, 0, 0, 0.2) !important;
+      background-color: rgba(0, 0, 0, 0.4) !important;
       opacity: 1 !important;
     }
     #TabsToolbar[brighttext]
@@ -7666,7 +7666,7 @@
       > .tab-stack
       > .tab-background
       > .tab-context-line::before {
-      background-color: rgba(255, 255, 255, 0.2) !important;
+      background-color: rgba(255, 255, 255, 0.4) !important;
     }
     /* Animation */
     @media (prefers-reduced-motion: no-preference) {
@@ -22505,7 +22505,7 @@
     > .tab-stack
     > .tab-background
     > .tab-context-line::before {
-    background-color: rgba(0, 0, 0, 0.2) !important;
+    background-color: rgba(0, 0, 0, 0.4) !important;
     opacity: 1 !important;
   }
   #TabsToolbar[brighttext]
@@ -22513,7 +22513,7 @@
     > .tab-stack
     > .tab-background
     > .tab-context-line::before {
-    background-color: rgba(255, 255, 255, 0.2) !important;
+    background-color: rgba(255, 255, 255, 0.4) !important;
   }
   /* Animation */
   /* Animation for hover effect */

--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -7615,52 +7615,49 @@
     margin: unset !important;
   }
 }
+/*= Selected Tab - Supernova like contextline ===================================*/
 @media not -moz-pref("userChrome.tab.photon_like_contextline") {
   @media -moz-pref("userChrome.tab.supernova_like_contextline") {
-    .tab-context-line {
+    /* context line styles */
+    tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line {
       display: inline-flex !important;
       display: -moz-inline-box !important;
+    }
+    tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line::before {
+      content: "";
       height: 1px !important;
       border-radius: 9999px !important;
       transform: translateY(5px);
       margin-top: -1px !important;
       margin-left: 5px;
       margin-right: 5px;
+      width: 100%;
     }
-    /* Override container tab style */
+    /* Override container-tab style */
     tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
-      margin-top: 3px !important;
-      margin-left: 5px !important;
-      margin-right: 5px !important;
+      margin: unset !important;
     }
-    tab.tabbrowser-tab[usercontextid]:not([selected="true"], [multiselected])
-      > .tab-stack
-      > .tab-background
-      > .tab-context-line {
-      opacity: 0;
-      transition: all 0.2s cubic-bezier(0, 0.9, 0.15, 1) !important;
-    }
+    /* selected tab style */
     :root[lwtheme-mozlightdark]:not([lwthemetextcolor="bright"]),
     :root[style*="--lwt-accent-color: rgb(240, 240, 244); --lwt-text-color: rgba(21, 20, 26);"] .tab-context-line,
     :root[lwtheme-mozlightdark][lwthemetextcolor="bright"],
     :root[style*="--lwt-accent-color: rgb(28, 27, 34); --lwt-text-color: rgba(251, 251, 254);"] .tab-context-line {
       --tab-line-color: #45a1ff;
     }
-    .tabbrowser-tab:is([selected], [multiselected]) .tab-context-line {
-      background-color: var(--tab-line-color, #45a1ff) !important;
+    .tabbrowser-tab:is([selected], [multiselected]) .tab-context-line::before {
+      background-color: var(--tab-line-color, var(--lwt-tab-line-color, #45a1ff)) !important;
     }
     /* Set the active effect */
-    tabs tab.tabbrowser-tab[usercontextid]:active > .tab-stack > .tab-background > .tab-context-line {
-      margin-left: 6px !important;
-      margin-right: 6px !important;
-    }
-    .tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line {
-      background: #217ddb !important;
+    .tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line::before {
+      filter: brightness(70%);
       margin-left: 6px;
       margin-right: 6px;
     }
     /* Set the hover effect */
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+      > .tab-stack
+      > .tab-background
+      > .tab-context-line::before {
       background-color: rgba(0, 0, 0, 0.2) !important;
       opacity: 1 !important;
     }
@@ -7668,20 +7665,16 @@
       .tabbrowser-tab:hover:not([selected="true"], [multiselected])
       > .tab-stack
       > .tab-background
-      > .tab-context-line {
-      background-color: rgba(255, 255, 255, 0.3137254902) !important;
+      > .tab-context-line::before {
+      background-color: rgba(255, 255, 255, 0.2) !important;
     }
     /* Animation */
     @media (prefers-reduced-motion: no-preference) {
-      .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
-        animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
-      }
-      /* Animation for container tab can't have width change... */
-      tab.tabbrowser-tab[usercontextid]:hover:not([selected="true"], [multiselected])
+      .tabbrowser-tab:hover:not([selected="true"], [multiselected])
         > .tab-stack
         > .tab-background
-        > .tab-context-line {
-        opacity: 1;
+        > .tab-context-line::before {
+        animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
       }
     }
     /* Animation for hover effect */
@@ -7723,6 +7716,23 @@
       > .tab-stack
       > .tab-background {
       box-shadow: 0 0 1px var(--tabs-border-color), 0 0 4px rgba(128, 128, 142, 0.5) !important; /* Original: 0 0 1px var(--tab-line-color, rgba(128,128,142,0.9)), 0 0 4px rgba(128,128,142,0.5) */
+    }
+    @media -moz-pref("userChrome.tab.contextline_blue_accent") {
+      #tabbrowser-tabs .tab-context-line {
+        --tab-line-color: #45a1ff !important;
+      }
+    }
+    @media not -moz-pref("userChrome.tab.contextline_blue_accent") {
+      @media (-moz-gtk-csd-available) {
+        :root:is(:not([lwtheme]), :not(:-moz-lwtheme)) #tabbrowser-tabs .tab-context-line {
+          --tab-line-color: AccentColor !important; /* -moz-accent-color */
+        }
+        @media -moz-pref("userChrome.compatibility.accent_color") {
+          :root:is(:not([lwtheme]), :not(:-moz-lwtheme)) #tabbrowser-tabs .tab-context-line {
+            --tab-line-color: Highlight !important; /* -moz-accent-color */
+          }
+        }
+      }
     }
   }
 }
@@ -22453,51 +22463,48 @@
     margin: unset !important;
   }
 }
+/*= Selected Tab - Supernova like contextline ===================================*/
 @media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") {
-  .tab-context-line {
+  /* context line styles */
+  tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line {
     display: inline-flex !important;
     display: -moz-inline-box !important;
+  }
+  tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line::before {
+    content: "";
     height: 1px !important;
     border-radius: 9999px !important;
     transform: translateY(5px);
     margin-top: -1px !important;
     margin-left: 5px;
     margin-right: 5px;
+    width: 100%;
   }
-  /* Override container tab style */
+  /* Override container-tab style */
   tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
-    margin-top: 3px !important;
-    margin-left: 5px !important;
-    margin-right: 5px !important;
+    margin: unset !important;
   }
-  tab.tabbrowser-tab[usercontextid]:not([selected="true"], [multiselected])
-    > .tab-stack
-    > .tab-background
-    > .tab-context-line {
-    opacity: 0;
-    transition: all 0.2s cubic-bezier(0, 0.9, 0.15, 1) !important;
-  }
+  /* selected tab style */
   :root[lwtheme-mozlightdark]:not([lwthemetextcolor="bright"]),
   :root[style*="--lwt-accent-color: rgb(240, 240, 244); --lwt-text-color: rgba(21, 20, 26);"] .tab-context-line,
   :root[lwtheme-mozlightdark][lwthemetextcolor="bright"],
   :root[style*="--lwt-accent-color: rgb(28, 27, 34); --lwt-text-color: rgba(251, 251, 254);"] .tab-context-line {
     --tab-line-color: #45a1ff;
   }
-  .tabbrowser-tab:is([selected], [multiselected]) .tab-context-line {
-    background-color: var(--tab-line-color, #45a1ff) !important;
+  .tabbrowser-tab:is([selected], [multiselected]) .tab-context-line::before {
+    background-color: var(--tab-line-color, var(--lwt-tab-line-color, #45a1ff)) !important;
   }
   /* Set the active effect */
-  tabs tab.tabbrowser-tab[usercontextid]:active > .tab-stack > .tab-background > .tab-context-line {
-    margin-left: 6px !important;
-    margin-right: 6px !important;
-  }
-  .tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line {
-    background: #217ddb !important;
+  .tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line::before {
+    filter: brightness(70%);
     margin-left: 6px;
     margin-right: 6px;
   }
   /* Set the hover effect */
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+    > .tab-stack
+    > .tab-background
+    > .tab-context-line::before {
     background-color: rgba(0, 0, 0, 0.2) !important;
     opacity: 1 !important;
   }
@@ -22505,8 +22512,8 @@
     .tabbrowser-tab:hover:not([selected="true"], [multiselected])
     > .tab-stack
     > .tab-background
-    > .tab-context-line {
-    background-color: rgba(255, 255, 255, 0.3137254902) !important;
+    > .tab-context-line::before {
+    background-color: rgba(255, 255, 255, 0.2) !important;
   }
   /* Animation */
   /* Animation for hover effect */
@@ -22515,15 +22522,11 @@
   /* Remove side's background color border */
 }
 @media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") and (prefers-reduced-motion: no-preference) {
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
-    animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
-  }
-  /* Animation for container tab can't have width change... */
-  tab.tabbrowser-tab[usercontextid]:hover:not([selected="true"], [multiselected])
+  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
     > .tab-stack
     > .tab-background
-    > .tab-context-line {
-    opacity: 1;
+    > .tab-context-line::before {
+    animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
   }
 }
 @media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") {
@@ -22570,6 +22573,21 @@
     > .tab-stack
     > .tab-background {
     box-shadow: 0 0 1px var(--tabs-border-color), 0 0 4px rgba(128, 128, 142, 0.5) !important; /* Original: 0 0 1px var(--tab-line-color, rgba(128,128,142,0.9)), 0 0 4px rgba(128,128,142,0.5) */
+  }
+}
+@media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") and (-moz-bool-pref: "userChrome.tab.contextline_blue_accent") {
+  #tabbrowser-tabs .tab-context-line {
+    --tab-line-color: #45a1ff !important;
+  }
+}
+@media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") and (not (-moz-bool-pref: "userChrome.tab.contextline_blue_accent")) and (-moz-gtk-csd-available) {
+  :root:is(:not([lwtheme]), :not(:-moz-lwtheme)) #tabbrowser-tabs .tab-context-line {
+    --tab-line-color: AccentColor !important; /* -moz-accent-color */
+  }
+}
+@media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") and (not (-moz-bool-pref: "userChrome.tab.contextline_blue_accent")) and (-moz-gtk-csd-available) and (-moz-bool-pref: "userChrome.compatibility.accent_color") {
+  :root:is(:not([lwtheme]), :not(:-moz-lwtheme)) #tabbrowser-tabs .tab-context-line {
+    --tab-line-color: Highlight !important; /* -moz-accent-color */
   }
 }
 /*= Unselected Tab - Divide line =============================================*/

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -8100,7 +8100,7 @@
       > .tab-stack
       > .tab-background
       > .tab-context-line::before {
-      background-color: rgba(0, 0, 0, 0.2) !important;
+      background-color: rgba(0, 0, 0, 0.4) !important;
       opacity: 1 !important;
     }
     #TabsToolbar[brighttext]
@@ -8108,7 +8108,7 @@
       > .tab-stack
       > .tab-background
       > .tab-context-line::before {
-      background-color: rgba(255, 255, 255, 0.2) !important;
+      background-color: rgba(255, 255, 255, 0.4) !important;
     }
     /* Animation */
     @media (prefers-reduced-motion: no-preference) {

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -8057,52 +8057,49 @@
     margin: unset !important;
   }
 }
+/*= Selected Tab - Supernova like contextline ===================================*/
 @supports not -moz-bool-pref("userChrome.tab.photon_like_contextline") {
   @supports -moz-bool-pref("userChrome.tab.supernova_like_contextline") {
-    .tab-context-line {
+    /* context line styles */
+    tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line {
       display: inline-flex !important;
       display: -moz-inline-box !important;
+    }
+    tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line::before {
+      content: "";
       height: 1px !important;
       border-radius: 9999px !important;
       transform: translateY(5px);
       margin-top: -1px !important;
       margin-left: 5px;
       margin-right: 5px;
+      width: 100%;
     }
-    /* Override container tab style */
+    /* Override container-tab style */
     tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
-      margin-top: 3px !important;
-      margin-left: 5px !important;
-      margin-right: 5px !important;
+      margin: unset !important;
     }
-    tab.tabbrowser-tab[usercontextid]:not([selected="true"], [multiselected])
-      > .tab-stack
-      > .tab-background
-      > .tab-context-line {
-      opacity: 0;
-      transition: all 0.2s cubic-bezier(0, 0.9, 0.15, 1) !important;
-    }
+    /* selected tab style */
     :root[lwtheme-mozlightdark]:not([lwthemetextcolor="bright"]),
     :root[style*="--lwt-accent-color: rgb(240, 240, 244); --lwt-text-color: rgba(21, 20, 26);"] .tab-context-line,
     :root[lwtheme-mozlightdark][lwthemetextcolor="bright"],
     :root[style*="--lwt-accent-color: rgb(28, 27, 34); --lwt-text-color: rgba(251, 251, 254);"] .tab-context-line {
       --tab-line-color: #45a1ff;
     }
-    .tabbrowser-tab:is([selected], [multiselected]) .tab-context-line {
-      background-color: var(--tab-line-color, #45a1ff) !important;
+    .tabbrowser-tab:is([selected], [multiselected]) .tab-context-line::before {
+      background-color: var(--tab-line-color, var(--lwt-tab-line-color, #45a1ff)) !important;
     }
     /* Set the active effect */
-    tabs tab.tabbrowser-tab[usercontextid]:active > .tab-stack > .tab-background > .tab-context-line {
-      margin-left: 6px !important;
-      margin-right: 6px !important;
-    }
-    .tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line {
-      background: #217ddb !important;
+    .tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line::before {
+      filter: brightness(70%);
       margin-left: 6px;
       margin-right: 6px;
     }
     /* Set the hover effect */
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+      > .tab-stack
+      > .tab-background
+      > .tab-context-line::before {
       background-color: rgba(0, 0, 0, 0.2) !important;
       opacity: 1 !important;
     }
@@ -8110,20 +8107,16 @@
       .tabbrowser-tab:hover:not([selected="true"], [multiselected])
       > .tab-stack
       > .tab-background
-      > .tab-context-line {
-      background-color: rgba(255, 255, 255, 0.3137254902) !important;
+      > .tab-context-line::before {
+      background-color: rgba(255, 255, 255, 0.2) !important;
     }
     /* Animation */
     @media (prefers-reduced-motion: no-preference) {
-      .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
-        animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
-      }
-      /* Animation for container tab can't have width change... */
-      tab.tabbrowser-tab[usercontextid]:hover:not([selected="true"], [multiselected])
+      .tabbrowser-tab:hover:not([selected="true"], [multiselected])
         > .tab-stack
         > .tab-background
-        > .tab-context-line {
-        opacity: 1;
+        > .tab-context-line::before {
+        animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
       }
     }
     /* Animation for hover effect */
@@ -8165,6 +8158,23 @@
       > .tab-stack
       > .tab-background {
       box-shadow: 0 0 1px var(--tabs-border-color), 0 0 4px rgba(128, 128, 142, 0.5) !important; /* Original: 0 0 1px var(--tab-line-color, rgba(128,128,142,0.9)), 0 0 4px rgba(128,128,142,0.5) */
+    }
+    @supports -moz-bool-pref("userChrome.tab.contextline_blue_accent") {
+      #tabbrowser-tabs .tab-context-line {
+        --tab-line-color: #45a1ff !important;
+      }
+    }
+    @supports not -moz-bool-pref("userChrome.tab.contextline_blue_accent") {
+      @media (-moz-gtk-csd-available) {
+        :root:is(:not([lwtheme]), :not(:-moz-lwtheme)) #tabbrowser-tabs .tab-context-line {
+          --tab-line-color: AccentColor !important; /* -moz-accent-color */
+        }
+        @supports -moz-bool-pref("userChrome.compatibility.accent_color") {
+          :root:is(:not([lwtheme]), :not(:-moz-lwtheme)) #tabbrowser-tabs .tab-context-line {
+            --tab-line-color: Highlight !important; /* -moz-accent-color */
+          }
+        }
+      }
     }
   }
 }

--- a/src/tab/_selected_tab.scss
+++ b/src/tab/_selected_tab.scss
@@ -68,8 +68,26 @@
   @import "selected_tab/photon_like_contextline";
 }
 
+/*= Selected Tab - Supernova like contextline ===================================*/
 @include NotOption("userChrome.tab.photon_like_contextline") {
   @include Option("userChrome.tab.supernova_like_contextline") {
     @import "selected_tab/supernova_like_contextline";
+
+    @include Option("userChrome.tab.contextline_blue_accent") {
+      #tabbrowser-tabs .tab-context-line {
+        --tab-line-color: #45a1ff !important;
+      }
+    }
+    @include NotOption("userChrome.tab.contextline_blue_accent") {
+      @include OS("linux") {
+        @include not_lwtheme {
+          #tabbrowser-tabs .tab-context-line {
+            @include AccentColor("Highlight") {
+              --tab-line-color: #{$accentColor} !important; /* -moz-accent-color */
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/tab/selected_tab/_supernova_like_contextline.scss
+++ b/src/tab/selected_tab/_supernova_like_contextline.scss
@@ -39,7 +39,7 @@ tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-con
   > .tab-stack
   > .tab-background
   > .tab-context-line::before {
-  background-color: rgba(0, 0, 0, 0.2) !important;
+  background-color: rgba(0, 0, 0, 0.4) !important;
   opacity: 1 !important;
 }
 
@@ -48,7 +48,7 @@ tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-con
   > .tab-stack
   > .tab-background
   > .tab-context-line::before {
-  background-color: rgba(255, 255, 255, 0.2) !important;
+  background-color: rgba(255, 255, 255, 0.4) !important;
 }
 
 

--- a/src/tab/selected_tab/_supernova_like_contextline.scss
+++ b/src/tab/selected_tab/_supernova_like_contextline.scss
@@ -1,50 +1,44 @@
-.tab-context-line {
+/* context line styles */
+tabs tab.tabbrowser-tab > .tab-stack > .tab-background > .tab-context-line {
   @include InlineBox(true);
-  height: 1px !important;
-  border-radius: 9999px !important;
-  transform: translateY(5px);
-  margin-top: -1px !important;
-  margin-left: 5px;
-  margin-right: 5px;
+  &::before {
+    content: "";
+    height: 1px !important;
+    border-radius: 9999px !important;
+    transform: translateY(5px);
+    margin-top: -1px !important;
+    margin-left: 5px;
+    margin-right: 5px;
+    width: 100%;
+  }
 }
 
-/* Override container tab style */
+/* Override container-tab style */
 tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
-  margin-top: 3px !important;
-  margin-left: 5px !important;
-  margin-right: 5px !important;
+  margin: unset !important;
 }
 
-tab.tabbrowser-tab[usercontextid]:not([selected="true"], [multiselected])
-  > .tab-stack
-  > .tab-background
-  > .tab-context-line {
-  opacity: 0;
-  transition: all 0.2s cubic-bezier(0, 0.9, 0.15, 1) !important;
-}
-
+/* selected tab style */
 #{built-in-light-theme()} .tab-context-line,
 #{built-in-dark-theme()} .tab-context-line {
   --tab-line-color: #45a1ff;
 }
-.tabbrowser-tab:is([selected], [multiselected]) .tab-context-line {
-  background-color: var(--tab-line-color, #45a1ff) !important;
+.tabbrowser-tab:is([selected], [multiselected]) .tab-context-line::before {
+  background-color: var(--tab-line-color, var(--lwt-tab-line-color, #45a1ff)) !important;
 }
 
 /* Set the active effect */
-tabs tab.tabbrowser-tab[usercontextid]:active > .tab-stack > .tab-background > .tab-context-line {
-  margin-left: 6px !important;
-  margin-right: 6px !important;
-}
-
-.tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line {
-  background: #217ddb !important;
+.tabbrowser-tab:active > .tab-stack > .tab-background > .tab-context-line::before {
+  filter: brightness(70%);
   margin-left: 6px;
   margin-right: 6px;
 }
 
 /* Set the hover effect */
-.tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+.tabbrowser-tab:hover:not([selected="true"], [multiselected])
+  > .tab-stack
+  > .tab-background
+  > .tab-context-line::before {
   background-color: rgba(0, 0, 0, 0.2) !important;
   opacity: 1 !important;
 }
@@ -53,22 +47,18 @@ tabs tab.tabbrowser-tab[usercontextid]:active > .tab-stack > .tab-background > .
   .tabbrowser-tab:hover:not([selected="true"], [multiselected])
   > .tab-stack
   > .tab-background
-  > .tab-context-line {
-  background-color: #ffffff50 !important;
+  > .tab-context-line::before {
+  background-color: rgba(255, 255, 255, 0.2) !important;
 }
+
 
 /* Animation */
 @media (prefers-reduced-motion: no-preference) {
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
-    animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
-  }
-
-  /* Animation for container tab can't have width change... */
-  tab.tabbrowser-tab[usercontextid]:hover:not([selected="true"], [multiselected])
+  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
     > .tab-stack
     > .tab-background
-    > .tab-context-line {
-    opacity: 1;
+    > .tab-context-line::before {
+    animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
   }
 }
 


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->
- fixed contextline's position is lower in container-tabs.
- fixed contextline animation is not working on container-tabs.

**PR Type**
<!-- Check like `- [x]`. -->

- [x] `Add:` Add feature or enhanced.
- [ ] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
none

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->
Contextline Position:
|Before|
|---|
|![Screenshot From 2025-05-11 01-16-10](https://github.com/user-attachments/assets/f07534c9-5a46-47e8-9e91-123f58c1d6ce)|

|After|
|---|
|![Screenshot From 2025-05-11 01-11-03](https://github.com/user-attachments/assets/9d8379c8-20e2-4de3-a518-6a03a6716937)|


Animation:
|Before|
|---|
|![output_before](https://github.com/user-attachments/assets/06acd91f-6036-4f87-8ce5-74e0cbd75239)|

|After|
|---|
|![output_after](https://github.com/user-attachments/assets/0b6c7164-1f0c-46bd-8706-90087f0ed12c)|

Contextline color synced with theme (Firefox Alpenglow):
|After|
|---|
|![Screenshot From 2025-05-11 01-22-14](https://github.com/user-attachments/assets/9ed15c8e-a4bd-4e9b-8454-1d193d84eed2)|

**Additional context**
<!-- Add any other context about the commit here. -->
- The background-color of supernova contextline is now synced with Firefox theme or OS accent color.
- Contextline is currently represented using pseudo-elements for animation and code integration in container-tabs.
- Added new option `userChrome.tab.contextline_blue_accent` to avoid the contextline color becoming the same as the background in some themes.