### PR TITLE
Fix: Icons - context menu overlap in linux #1113

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -1248,8 +1248,11 @@
       width: unset !important;
     }
     .menu-iconic-left .menu-iconic-icon,
+    .menu-iconic-left .menu-icon,
     menuitem[type="checkbox"] .menu-iconic-icon,
-    menuitem[type="radio"] .menu-iconic-icon {
+    menuitem[type="checkbox"] .menu-icon,
+    menuitem[type="radio"] .menu-iconic-icon,
+    menuitem[type="radio"] .menu-icon {
       appearance: none !important;
     }
   }
@@ -1278,7 +1281,8 @@
     }
   }
   @media (-moz-gtk-csd-available) {
-    menuitem[checked="true"] > .menu-iconic-left {
+    menuitem[checked="true"] > .menu-iconic-left,
+    menuitem[checked="true"] > .menu-icon {
       -moz-context-properties: fill, fill-opacity !important;
       fill: currentColor !important;
       fill-opacity: var(--menu-icon-opacity) !important;
@@ -1308,7 +1312,7 @@
   @media (-moz-gtk-csd-available) {
     menupopup {
       /* Disable the default appearance so we can override the native styling. */
-      appearance: none !important !important;
+      appearance: none !important;
       /* Prevent any background or border around the outside of the shadow. */
       background-color: transparent !important;
       border: none !important;
@@ -1391,13 +1395,15 @@
     }
   }
   @media (-moz-gtk-csd-available) {
-    #context-navigation > .menuitem-iconic > .menu-iconic-left {
+    #context-navigation > .menuitem-iconic > .menu-iconic-left,
+    #context-navigation > .menuitem-iconic > .menu-icon {
       margin: 0 !important;
       padding: 0 !important;
     }
   }
   @media (-moz-gtk-csd-available) {
-    #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon {
+    #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon,
+    #context-navigation > .menuitem-iconic > .menu-icon {
       width: var(--menuitem-min-width) !important;
       height: 32px !important;
       padding: 8px 1em !important;
@@ -1405,7 +1411,8 @@
     }
   }
   @media (-moz-gtk-csd-available) {
-    #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon {
+    #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon,
+    #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-icon {
       background-color: var(--menuitem-hover-background-color) !important;
     }
   }
@@ -1413,7 +1420,8 @@
     #context-navigation
       > .menuitem-iconic[_moz-menuactive="true"][disabled="true"]
       > .menu-iconic-left
-      > .menu-iconic-icon {
+      > .menu-iconic-icon,
+    #context-navigation > .menuitem-iconic[_moz-menuactive="true"][disabled="true"] > .menu-icon {
       background-color: transparent !important;
     }
   }
@@ -12050,7 +12058,9 @@
     menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
     menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
     menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+    menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
     menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+    menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
     #main-menubar > menu {
       -moz-appearance: none !important; /* Linux: menulist */
     }
@@ -12392,6 +12402,9 @@
       }
       #main-menubar > menu > .menubar-text {
         padding-inline-start: 3px;
+      }
+      .menu-icon {
+        display: unset !important;
       }
     }
     /* Padding - Mac */
@@ -15416,8 +15429,11 @@
     width: unset !important;
   }
   .menu-iconic-left .menu-iconic-icon,
+  .menu-iconic-left .menu-icon,
   menuitem[type="checkbox"] .menu-iconic-icon,
-  menuitem[type="radio"] .menu-iconic-icon {
+  menuitem[type="checkbox"] .menu-icon,
+  menuitem[type="radio"] .menu-iconic-icon,
+  menuitem[type="radio"] .menu-icon {
     appearance: none !important;
   }
 }
@@ -15446,7 +15462,8 @@
   }
 }
 @media (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available) {
-  menuitem[checked="true"] > .menu-iconic-left {
+  menuitem[checked="true"] > .menu-iconic-left,
+  menuitem[checked="true"] > .menu-icon {
     -moz-context-properties: fill, fill-opacity !important;
     fill: currentColor !important;
     fill-opacity: var(--menu-icon-opacity) !important;
@@ -15476,7 +15493,7 @@
 @media (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available) {
   menupopup {
     /* Disable the default appearance so we can override the native styling. */
-    appearance: none !important !important;
+    appearance: none !important;
     /* Prevent any background or border around the outside of the shadow. */
     background-color: transparent !important;
     border: none !important;
@@ -15559,13 +15576,15 @@
   }
 }
 @media (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available) {
-  #context-navigation > .menuitem-iconic > .menu-iconic-left {
+  #context-navigation > .menuitem-iconic > .menu-iconic-left,
+  #context-navigation > .menuitem-iconic > .menu-icon {
     margin: 0 !important;
     padding: 0 !important;
   }
 }
 @media (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available) {
-  #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon {
+  #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon,
+  #context-navigation > .menuitem-iconic > .menu-icon {
     width: var(--menuitem-min-width) !important;
     height: 32px !important;
     padding: 8px 1em !important;
@@ -15573,7 +15592,8 @@
   }
 }
 @media (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available) {
-  #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon {
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon,
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-icon {
     background-color: var(--menuitem-hover-background-color) !important;
   }
 }
@@ -15581,7 +15601,8 @@
   #context-navigation
     > .menuitem-iconic[_moz-menuactive="true"][disabled="true"]
     > .menu-iconic-left
-    > .menu-iconic-icon {
+    > .menu-iconic-icon,
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"][disabled="true"] > .menu-icon {
     background-color: transparent !important;
   }
 }
@@ -27584,7 +27605,9 @@
   menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
   menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
   menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+  menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
   menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+  menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
   #main-menubar > menu {
     -moz-appearance: none !important; /* Linux: menulist */
   }
@@ -27935,6 +27958,9 @@
   }
   #main-menubar > menu > .menubar-text {
     padding-inline-start: 3px;
+  }
+  .menu-icon {
+    display: unset !important;
   }
 }
 @media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -1471,8 +1471,11 @@
       width: unset !important;
     }
     .menu-iconic-left .menu-iconic-icon,
+    .menu-iconic-left .menu-icon,
     menuitem[type="checkbox"] .menu-iconic-icon,
-    menuitem[type="radio"] .menu-iconic-icon {
+    menuitem[type="checkbox"] .menu-icon,
+    menuitem[type="radio"] .menu-iconic-icon,
+    menuitem[type="radio"] .menu-icon {
       appearance: none !important;
     }
   }
@@ -1501,7 +1504,8 @@
     }
   }
   @media (-moz-gtk-csd-available) {
-    menuitem[checked="true"] > .menu-iconic-left {
+    menuitem[checked="true"] > .menu-iconic-left,
+    menuitem[checked="true"] > .menu-icon {
       -moz-context-properties: fill, fill-opacity !important;
       fill: currentColor !important;
       fill-opacity: var(--menu-icon-opacity) !important;
@@ -1531,7 +1535,7 @@
   @media (-moz-gtk-csd-available) {
     menupopup {
       /* Disable the default appearance so we can override the native styling. */
-      appearance: none !important !important;
+      appearance: none !important;
       /* Prevent any background or border around the outside of the shadow. */
       background-color: transparent !important;
       border: none !important;
@@ -1614,13 +1618,15 @@
     }
   }
   @media (-moz-gtk-csd-available) {
-    #context-navigation > .menuitem-iconic > .menu-iconic-left {
+    #context-navigation > .menuitem-iconic > .menu-iconic-left,
+    #context-navigation > .menuitem-iconic > .menu-icon {
       margin: 0 !important;
       padding: 0 !important;
     }
   }
   @media (-moz-gtk-csd-available) {
-    #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon {
+    #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon,
+    #context-navigation > .menuitem-iconic > .menu-icon {
       width: var(--menuitem-min-width) !important;
       height: 32px !important;
       padding: 8px 1em !important;
@@ -1628,7 +1634,8 @@
     }
   }
   @media (-moz-gtk-csd-available) {
-    #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon {
+    #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon,
+    #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-icon {
       background-color: var(--menuitem-hover-background-color) !important;
     }
   }
@@ -1636,7 +1643,8 @@
     #context-navigation
       > .menuitem-iconic[_moz-menuactive="true"][disabled="true"]
       > .menu-iconic-left
-      > .menu-iconic-icon {
+      > .menu-iconic-icon,
+    #context-navigation > .menuitem-iconic[_moz-menuactive="true"][disabled="true"] > .menu-icon {
       background-color: transparent !important;
     }
   }
@@ -12532,7 +12540,9 @@
     menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
     menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
     menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+    menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
     menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+    menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
     #main-menubar > menu {
       -moz-appearance: none !important; /* Linux: menulist */
     }
@@ -13055,6 +13065,9 @@
       }
       #main-menubar > menu > .menubar-text {
         padding-inline-start: 3px;
+      }
+      .menu-icon {
+        display: unset !important;
       }
     }
     /* Padding - Mac */

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -3318,7 +3318,9 @@
       menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
       menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
       menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
-      menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon {
+      menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
+      menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+      menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon {
         -moz-appearance: none !important; /* Linux: menulist */
       }
       menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
@@ -3434,6 +3436,9 @@
           --context-menu-background-padding-default: 6px;
           --context-menu-text-padding: 21px;
         }
+        .menu-icon {
+          display: unset !important;
+        }
         /* Contextmenu Checkbox Unset */
         menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu) menuitem[type="checkbox"] {
           margin-inline: 0 !important;
@@ -3441,13 +3446,19 @@
         menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
           menuitem[type="checkbox"]
           > .menu-iconic-left
-          > .menu-iconic-icon {
+          > .menu-iconic-icon,
+        menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
+          menuitem[type="checkbox"]
+          > .menu-icon {
           margin-inline-end: 0 !important;
         }
         menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
           menuitem[type="checkbox"]:not([checked="true"])
           > .menu-iconic-left
-          > .menu-iconic-icon {
+          > .menu-iconic-icon,
+        menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
+          menuitem[type="checkbox"]:not([checked="true"])
+          > .menu-icon {
           border: none !important;
           background-color: unset !important;
         }
@@ -7165,7 +7176,9 @@
     menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
     menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
     menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
-    menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon {
+    menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
+    menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+    menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon {
       -moz-appearance: none !important; /* Linux: menulist */
     }
     menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
@@ -7277,6 +7290,9 @@
         --context-menu-background-padding-default: 6px;
         --context-menu-text-padding: 21px;
       }
+      .menu-icon {
+        display: unset !important;
+      }
       /* Contextmenu Checkbox Unset */
       menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu) menuitem[type="checkbox"] {
         margin-inline: 0 !important;
@@ -7284,13 +7300,19 @@
       menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
         menuitem[type="checkbox"]
         > .menu-iconic-left
-        > .menu-iconic-icon {
+        > .menu-iconic-icon,
+      menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
+        menuitem[type="checkbox"]
+        > .menu-icon {
         margin-inline-end: 0 !important;
       }
       menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
         menuitem[type="checkbox"]:not([checked="true"])
         > .menu-iconic-left
-        > .menu-iconic-icon {
+        > .menu-iconic-icon,
+      menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
+        menuitem[type="checkbox"]:not([checked="true"])
+        > .menu-icon {
         border: none !important;
         background-color: unset !important;
       }

--- a/css/leptonContentESR.css
+++ b/css/leptonContentESR.css
@@ -3321,7 +3321,9 @@
       menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
       menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
       menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
-      menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon {
+      menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon,
+      menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
+      menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-icon {
         -moz-appearance: none !important; /* Linux: menulist */
       }
       menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
@@ -3573,6 +3575,9 @@
           --context-menu-background-padding-default: 6px;
           --context-menu-text-padding: 21px;
         }
+        .menu-icon {
+          display: unset !important;
+        }
         /* Contextmenu Checkbox Unset */
         menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu) menuitem[type="checkbox"] {
           margin-inline: 0 !important;
@@ -3580,13 +3585,19 @@
         menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
           menuitem[type="checkbox"]
           > .menu-iconic-left
-          > .menu-iconic-icon {
+          > .menu-iconic-icon,
+        menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
+          menuitem[type="checkbox"]
+          > .menu-icon {
           margin-inline-end: 0 !important;
         }
         menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
           menuitem[type="checkbox"]:not([checked="true"])
           > .menu-iconic-left
-          > .menu-iconic-icon {
+          > .menu-iconic-icon,
+        menupopup:is(#placesContext, #placesColumnsContext, #downloadsContextMenu)
+          menuitem[type="checkbox"]:not([checked="true"])
+          > .menu-icon {
           border: none !important;
           background-color: unset !important;
         }

--- a/src/icons/layout/_menu_common.scss
+++ b/src/icons/layout/_menu_common.scss
@@ -41,7 +41,7 @@ $_initialMenus: selector.append(
   $_checkMenu
 );
 $_initialMenus: $_initialMenus + "," +
-                selector.nest($_initialMenus, "> .menu-iconic-left > .menu-iconic-icon");
+                selector.nest($_initialMenus, "> .menu-iconic-left > .menu-iconic-icon, > .menu-icon");
 @mixin _initial_menus() {
   -moz-appearance: none !important; /* Linux: menulist */
 }
@@ -191,6 +191,9 @@ $_initialMenus: $_initialMenus + "," +
     // https://github.com/mozilla/gecko-dev/commit/e54707888510dec75db59a170b287d1db031505a
     // https://github.com/mozilla/gecko-dev/blob/e54707888510dec75db59a170b287d1db031505a/toolkit/themes/linux/global/menu.css#L103
     --context-menu-text-padding: 21px;
+  }
+  .menu-icon {
+    display: unset !important;
   }
 }
 @mixin _layout_init_linux() {

--- a/src/icons/layout/_menu_contents.scss
+++ b/src/icons/layout/_menu_contents.scss
@@ -61,10 +61,12 @@ $_placesPopupSetMenus: selector.nest(
   /* Contextmenu Checkbox Unset */
   #{$_placesPopupSet} menuitem[type="checkbox"] {
     margin-inline: 0 !important;
-    > .menu-iconic-left > .menu-iconic-icon {
+    > .menu-iconic-left > .menu-iconic-icon,
+    > .menu-icon {
       margin-inline-end: 0 !important;
     }
-    &:not([checked="true"]) > .menu-iconic-left > .menu-iconic-icon {
+    &:not([checked="true"]) > .menu-iconic-left > .menu-iconic-icon,
+    &:not([checked="true"]) > .menu-icon {
       border: none !important;
       background-color: unset !important;
     }

--- a/src/theme/_non_native_menu.scss
+++ b/src/theme/_non_native_menu.scss
@@ -100,7 +100,8 @@
   menuitem[type="radio"] {
     appearance: none !important; /* to override more specific selectors above. */
     width: unset !important;
-    .menu-iconic-icon {
+    .menu-iconic-icon,
+    .menu-icon {
       appearance: none !important;
     }
   }
@@ -128,7 +129,8 @@
      checkboxes and radio buttons because the native drawing we use on other
      Windows versions looks pretty bad with the Win10 styles, so for now we'll
      insert a generic checkmark icon for both types. */
-  menuitem[checked="true"] > .menu-iconic-left {
+  menuitem[checked="true"] > .menu-iconic-left,
+  menuitem[checked="true"] > .menu-icon {
     -moz-context-properties: fill, fill-opacity !important;
     fill: currentColor !important;
     fill-opacity: var(--menu-icon-opacity) !important;
@@ -157,7 +159,7 @@
   //-- Global - Menu Popup -----------------------------------------------------
   menupopup {
     /* Disable the default appearance so we can override the native styling. */
-    appearance: none !important !important;
+    appearance: none !important;
 
     /* Prevent any background or border around the outside of the shadow. */
     background-color: transparent !important;
@@ -233,23 +235,27 @@
     background-color: transparent !important;
   }
 
-  #context-navigation > .menuitem-iconic > .menu-iconic-left {
+  #context-navigation > .menuitem-iconic > .menu-iconic-left,
+  #context-navigation > .menuitem-iconic > .menu-icon {
     margin: 0 !important;
     padding: 0 !important;
   }
 
   /* override styles from shared/contextmenu.inc.css */
-  #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon {
+  #context-navigation > .menuitem-iconic > .menu-iconic-left > .menu-iconic-icon,
+  #context-navigation > .menuitem-iconic > .menu-icon {
     width: var(--menuitem-min-width) !important;
     height: 32px !important;
     padding: 8px 1em !important;
     margin: 0 !important;
   }
-  #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon {
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-iconic-left > .menu-iconic-icon,
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"] > .menu-icon {
     background-color: var(--menuitem-hover-background-color) !important; // -moz-menuhover
   }
 
-  #context-navigation > .menuitem-iconic[_moz-menuactive="true"][disabled="true"] > .menu-iconic-left > .menu-iconic-icon {
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"][disabled="true"] > .menu-iconic-left > .menu-iconic-icon,
+  #context-navigation > .menuitem-iconic[_moz-menuactive="true"][disabled="true"] > .menu-icon {
     background-color: transparent !important;// -moz-menuhoverdisabled
   }
 


### PR DESCRIPTION
**Describe the PR**
This commit fixes the context menu icons and text colliding with each other.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
#1113, #1099

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->
Before:
![](https://github.com/user-attachments/assets/86e81d2f-1e81-4ec9-9536-69cc98766152)
After:
![](https://github.com/user-attachments/assets/71f2899f-2ddf-415a-a91c-a6c7be507239)

**Additional context**
<!-- Add any other context about the commit here. -->
This commit is based on 911c3f524b5083d5cec14d82a64420a55590a55a