### PR TITLE
Fix context menu icon padding

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -12471,11 +12471,71 @@
         padding-inline-start: var(--menu-background-padding-default) !important;
         margin-left: 0 !important;
       }
+      :not(menu, #ContentSelectDropdown, #context-navigation)
+        > menupopup:not(.in-menulist)
+        > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+        > .menu-icon,
+      :not(menu, #ContentSelectDropdown, #context-navigation)
+        > menupopup:not(.in-menulist)
+        > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(
+          #menu_FilePopup,
+          #menu_EditPopup,
+          #menu_viewPopup,
+          #goPopup,
+          #historyMenuPopup,
+          #bookmarksMenuPopup,
+          #menu_ProfilesPopup,
+          #menu_ToolsPopup,
+          #windowPopup,
+          #menu_HelpPopup,
+          #usercssloader-menupopup,
+          #sidebar-context-menu
+        )
+        menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(
+          #menu_FilePopup,
+          #menu_EditPopup,
+          #menu_viewPopup,
+          #goPopup,
+          #historyMenuPopup,
+          #bookmarksMenuPopup,
+          #menu_ProfilesPopup,
+          #menu_ToolsPopup,
+          #windowPopup,
+          #menu_HelpPopup,
+          #usercssloader-menupopup,
+          #sidebar-context-menu
+        )
+        menu:not(.menu-iconic, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(#organizeButtonPopup, #maintenanceButtonPopup)
+        > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(#viewMenuPopup, #maintenanceButtonPopup)
+        > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(
+          #context_sendTabToDevicePopupMenu,
+          #context-sendpagetodevice-popup,
+          #context-sendlinktodevice-popup,
+          #frame > menupopup,
+          #spell-dictionaries-menu,
+          #context-ask-chat > menupopup
+        )
+        > menuitem:not([type="checkbox"][checked="true"], [type="radio"])
+        > .menu-icon,
+      .openintabs-menuitem > .menu-icon,
+      #blockedPopupDontShowMessage > .menu-icon,
+      #BMB_viewBookmarksToolbar > .menu-icon,
+      #sidebarMenu-popup:is(menupopup) > .menu-icon,
+      #context_openANewTab.tabmix-newtab-menu-icon > .menu-icon {
+        display: none !important;
+      }
       .menupopup-arrowscrollbox {
         padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-      }
-      menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-        display: none !important;
       }
     }
     @media (-moz-platform: windows), (-moz-gtk-csd-available) {
@@ -12548,11 +12608,71 @@
             padding-inline-start: var(--menu-background-padding-default) !important;
             margin-left: 0 !important;
           }
+          :not(menu, #ContentSelectDropdown, #context-navigation)
+            > menupopup:not(.in-menulist)
+            > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+            > .menu-icon,
+          :not(menu, #ContentSelectDropdown, #context-navigation)
+            > menupopup:not(.in-menulist)
+            > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(
+              #menu_FilePopup,
+              #menu_EditPopup,
+              #menu_viewPopup,
+              #goPopup,
+              #historyMenuPopup,
+              #bookmarksMenuPopup,
+              #menu_ProfilesPopup,
+              #menu_ToolsPopup,
+              #windowPopup,
+              #menu_HelpPopup,
+              #usercssloader-menupopup,
+              #sidebar-context-menu
+            )
+            menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(
+              #menu_FilePopup,
+              #menu_EditPopup,
+              #menu_viewPopup,
+              #goPopup,
+              #historyMenuPopup,
+              #bookmarksMenuPopup,
+              #menu_ProfilesPopup,
+              #menu_ToolsPopup,
+              #windowPopup,
+              #menu_HelpPopup,
+              #usercssloader-menupopup,
+              #sidebar-context-menu
+            )
+            menu:not(.menu-iconic, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(#organizeButtonPopup, #maintenanceButtonPopup)
+            > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(#viewMenuPopup, #maintenanceButtonPopup)
+            > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(
+              #context_sendTabToDevicePopupMenu,
+              #context-sendpagetodevice-popup,
+              #context-sendlinktodevice-popup,
+              #frame > menupopup,
+              #spell-dictionaries-menu,
+              #context-ask-chat > menupopup
+            )
+            > menuitem:not([type="checkbox"][checked="true"], [type="radio"])
+            > .menu-icon,
+          .openintabs-menuitem > .menu-icon,
+          #blockedPopupDontShowMessage > .menu-icon,
+          #BMB_viewBookmarksToolbar > .menu-icon,
+          #sidebarMenu-popup:is(menupopup) > .menu-icon,
+          #context_openANewTab.tabmix-newtab-menu-icon > .menu-icon {
+            display: none !important;
+          }
           .menupopup-arrowscrollbox {
             padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-          }
-          menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-            display: none !important;
           }
         }
       }
@@ -28260,11 +28380,71 @@
     padding-inline-start: var(--menu-background-padding-default) !important;
     margin-left: 0 !important;
   }
+  :not(menu, #ContentSelectDropdown, #context-navigation)
+    > menupopup:not(.in-menulist)
+    > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+    > .menu-icon,
+  :not(menu, #ContentSelectDropdown, #context-navigation)
+    > menupopup:not(.in-menulist)
+    > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(
+      #menu_FilePopup,
+      #menu_EditPopup,
+      #menu_viewPopup,
+      #goPopup,
+      #historyMenuPopup,
+      #bookmarksMenuPopup,
+      #menu_ProfilesPopup,
+      #menu_ToolsPopup,
+      #windowPopup,
+      #menu_HelpPopup,
+      #usercssloader-menupopup,
+      #sidebar-context-menu
+    )
+    menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(
+      #menu_FilePopup,
+      #menu_EditPopup,
+      #menu_viewPopup,
+      #goPopup,
+      #historyMenuPopup,
+      #bookmarksMenuPopup,
+      #menu_ProfilesPopup,
+      #menu_ToolsPopup,
+      #windowPopup,
+      #menu_HelpPopup,
+      #usercssloader-menupopup,
+      #sidebar-context-menu
+    )
+    menu:not(.menu-iconic, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(#organizeButtonPopup, #maintenanceButtonPopup)
+    > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(#viewMenuPopup, #maintenanceButtonPopup)
+    > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(
+      #context_sendTabToDevicePopupMenu,
+      #context-sendpagetodevice-popup,
+      #context-sendlinktodevice-popup,
+      #frame > menupopup,
+      #spell-dictionaries-menu,
+      #context-ask-chat > menupopup
+    )
+    > menuitem:not([type="checkbox"][checked="true"], [type="radio"])
+    > .menu-icon,
+  .openintabs-menuitem > .menu-icon,
+  #blockedPopupDontShowMessage > .menu-icon,
+  #BMB_viewBookmarksToolbar > .menu-icon,
+  #sidebarMenu-popup:is(menupopup) > .menu-icon,
+  #context_openANewTab.tabmix-newtab-menu-icon > .menu-icon {
+    display: none !important;
+  }
   .menupopup-arrowscrollbox {
     padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-  }
-  menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-    display: none !important;
   }
 }
 @media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-platform: windows) and (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available),
@@ -28332,11 +28512,71 @@
     padding-inline-start: var(--menu-background-padding-default) !important;
     margin-left: 0 !important;
   }
+  :not(menu, #ContentSelectDropdown, #context-navigation)
+    > menupopup:not(.in-menulist)
+    > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+    > .menu-icon,
+  :not(menu, #ContentSelectDropdown, #context-navigation)
+    > menupopup:not(.in-menulist)
+    > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(
+      #menu_FilePopup,
+      #menu_EditPopup,
+      #menu_viewPopup,
+      #goPopup,
+      #historyMenuPopup,
+      #bookmarksMenuPopup,
+      #menu_ProfilesPopup,
+      #menu_ToolsPopup,
+      #windowPopup,
+      #menu_HelpPopup,
+      #usercssloader-menupopup,
+      #sidebar-context-menu
+    )
+    menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(
+      #menu_FilePopup,
+      #menu_EditPopup,
+      #menu_viewPopup,
+      #goPopup,
+      #historyMenuPopup,
+      #bookmarksMenuPopup,
+      #menu_ProfilesPopup,
+      #menu_ToolsPopup,
+      #windowPopup,
+      #menu_HelpPopup,
+      #usercssloader-menupopup,
+      #sidebar-context-menu
+    )
+    menu:not(.menu-iconic, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(#organizeButtonPopup, #maintenanceButtonPopup)
+    > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(#viewMenuPopup, #maintenanceButtonPopup)
+    > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+    > .menu-icon,
+  menupopup:is(
+      #context_sendTabToDevicePopupMenu,
+      #context-sendpagetodevice-popup,
+      #context-sendlinktodevice-popup,
+      #frame > menupopup,
+      #spell-dictionaries-menu,
+      #context-ask-chat > menupopup
+    )
+    > menuitem:not([type="checkbox"][checked="true"], [type="radio"])
+    > .menu-icon,
+  .openintabs-menuitem > .menu-icon,
+  #blockedPopupDontShowMessage > .menu-icon,
+  #BMB_viewBookmarksToolbar > .menu-icon,
+  #sidebarMenu-popup:is(menupopup) > .menu-icon,
+  #context_openANewTab.tabmix-newtab-menu-icon > .menu-icon {
+    display: none !important;
+  }
   .menupopup-arrowscrollbox {
     padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-  }
-  menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-    display: none !important;
   }
 }
 @media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-platform: windows) {

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -12960,11 +12960,71 @@
         padding-inline-start: var(--menu-background-padding-default) !important;
         margin-left: 0 !important;
       }
+      :not(menu, #ContentSelectDropdown, #context-navigation)
+        > menupopup:not(.in-menulist)
+        > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+        > .menu-icon,
+      :not(menu, #ContentSelectDropdown, #context-navigation)
+        > menupopup:not(.in-menulist)
+        > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(
+          #menu_FilePopup,
+          #menu_EditPopup,
+          #menu_viewPopup,
+          #goPopup,
+          #historyMenuPopup,
+          #bookmarksMenuPopup,
+          #menu_ProfilesPopup,
+          #menu_ToolsPopup,
+          #windowPopup,
+          #menu_HelpPopup,
+          #usercssloader-menupopup,
+          #sidebar-context-menu
+        )
+        menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(
+          #menu_FilePopup,
+          #menu_EditPopup,
+          #menu_viewPopup,
+          #goPopup,
+          #historyMenuPopup,
+          #bookmarksMenuPopup,
+          #menu_ProfilesPopup,
+          #menu_ToolsPopup,
+          #windowPopup,
+          #menu_HelpPopup,
+          #usercssloader-menupopup,
+          #sidebar-context-menu
+        )
+        menu:not(.menu-iconic, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(#organizeButtonPopup, #maintenanceButtonPopup)
+        > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(#viewMenuPopup, #maintenanceButtonPopup)
+        > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+        > .menu-icon,
+      menupopup:is(
+          #context_sendTabToDevicePopupMenu,
+          #context-sendpagetodevice-popup,
+          #context-sendlinktodevice-popup,
+          #frame > menupopup,
+          #spell-dictionaries-menu,
+          #context-ask-chat > menupopup
+        )
+        > menuitem:not([type="checkbox"][checked="true"], [type="radio"])
+        > .menu-icon,
+      .openintabs-menuitem > .menu-icon,
+      #blockedPopupDontShowMessage > .menu-icon,
+      #BMB_viewBookmarksToolbar > .menu-icon,
+      #sidebarMenu-popup:is(menupopup) > .menu-icon,
+      #context_openANewTab.tabmix-newtab-menu-icon > .menu-icon {
+        display: none !important;
+      }
       .menupopup-arrowscrollbox {
         padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-      }
-      menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-        display: none !important;
       }
     }
     @media (-moz-os-version: windows-win7),
@@ -13044,11 +13104,71 @@
             padding-inline-start: var(--menu-background-padding-default) !important;
             margin-left: 0 !important;
           }
+          :not(menu, #ContentSelectDropdown, #context-navigation)
+            > menupopup:not(.in-menulist)
+            > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+            > .menu-icon,
+          :not(menu, #ContentSelectDropdown, #context-navigation)
+            > menupopup:not(.in-menulist)
+            > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(
+              #menu_FilePopup,
+              #menu_EditPopup,
+              #menu_viewPopup,
+              #goPopup,
+              #historyMenuPopup,
+              #bookmarksMenuPopup,
+              #menu_ProfilesPopup,
+              #menu_ToolsPopup,
+              #windowPopup,
+              #menu_HelpPopup,
+              #usercssloader-menupopup,
+              #sidebar-context-menu
+            )
+            menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(
+              #menu_FilePopup,
+              #menu_EditPopup,
+              #menu_viewPopup,
+              #goPopup,
+              #historyMenuPopup,
+              #bookmarksMenuPopup,
+              #menu_ProfilesPopup,
+              #menu_ToolsPopup,
+              #windowPopup,
+              #menu_HelpPopup,
+              #usercssloader-menupopup,
+              #sidebar-context-menu
+            )
+            menu:not(.menu-iconic, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(#organizeButtonPopup, #maintenanceButtonPopup)
+            > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(#viewMenuPopup, #maintenanceButtonPopup)
+            > menu:not(.menu-iconic, .in-menulist, [checked="true"])
+            > .menu-icon,
+          menupopup:is(
+              #context_sendTabToDevicePopupMenu,
+              #context-sendpagetodevice-popup,
+              #context-sendlinktodevice-popup,
+              #frame > menupopup,
+              #spell-dictionaries-menu,
+              #context-ask-chat > menupopup
+            )
+            > menuitem:not([type="checkbox"][checked="true"], [type="radio"])
+            > .menu-icon,
+          .openintabs-menuitem > .menu-icon,
+          #blockedPopupDontShowMessage > .menu-icon,
+          #BMB_viewBookmarksToolbar > .menu-icon,
+          #sidebarMenu-popup:is(menupopup) > .menu-icon,
+          #context_openANewTab.tabmix-newtab-menu-icon > .menu-icon {
+            display: none !important;
+          }
           .menupopup-arrowscrollbox {
             padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-          }
-          menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-            display: none !important;
           }
         }
       }

--- a/src/icons/layout/_menu.scss
+++ b/src/icons/layout/_menu.scss
@@ -102,16 +102,16 @@ $_layoutCommonMenus: (
     @include _layout_root_non_native;
     @include _layoutIconMenus {
       @include _layout_init_non_native();
+
+      // FF v141 #1128
+      > .menu-icon {
+        display: none !important;
+      }
     }
 
     // FF v121
     .menupopup-arrowscrollbox {
       padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
-    }
-
-    // FF v141 #1128
-    menupopup[needsgutter] > :is(menu, menuitem) > .menu-icon {
-      display: none !important;
     }
   }
 }


### PR DESCRIPTION
**Describe the PR**
A follow-up for 4645a41e7edd5c5ad895549dc9a1342b492d8323.
This PR intends to fix some oversights of the previous commit, which led to some icons being hidden where not needed.
See screenshots for more details.

**PR Type**

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
#1128

**Screenshots**
Before:
<img height=300 alt="image" src="https://github.com/user-attachments/assets/8843b43a-2680-499e-b752-20fe88954223" /><img height=300 alt="image" src="https://github.com/user-attachments/assets/56785811-b94a-4653-94ef-9e3434f4f830" />
<img height=300 alt="image" src="https://github.com/user-attachments/assets/bb33a364-ae85-477c-a66b-84629887cfb6" /><img height=300 alt="image" src="https://github.com/user-attachments/assets/d77422bb-312e-4dd6-aebe-420d69edf6a5" />
After:
<img height=300 alt="image" src="https://github.com/user-attachments/assets/c0e3945f-1aec-49b7-bac6-60226e803bf3" /><img height=300 alt="image" src="https://github.com/user-attachments/assets/a9652b07-26f5-47e4-81d4-a901bcef17ba" />
<img height=300 alt="image" src="https://github.com/user-attachments/assets/85f18f44-14fe-445a-ba81-c7cc77ead1fa" /><img height=300 alt="image" src="https://github.com/user-attachments/assets/310bc803-c175-46ae-89b0-c8b39f0cdc24" />