### PR TITLE
add Waterfox Flatpak profile path to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -345,6 +345,7 @@ firefoxProfileDirPaths=(
   "${HOME}/.local/opt/tor-browser/app/Browser/TorBrowser/Data/Browser"
   "${HOME}/.var/app/org.mozilla.firefox/.mozilla/firefox"
   "${HOME}/.var/app/io.gitlab.librewolf-community/.librewolf"
+  "${HOME}/.var/app/net.waterfox.waterfox/.waterfox"
   "${HOME}/snap/firefox/common/.mozilla/firefox"
   "${HOME}/Library/Application Support/Firefox"
   "${HOME}/Library/Application Support/Waterfox"


### PR DESCRIPTION
Now the script successfully finds my Waterfox install. (Bazzite 43, flatpak)

<img width="640" height="273" alt="image" src="https://github.com/user-attachments/assets/e2912b20-02e3-4a44-ae01-ae9b0b59a624" />
