### PR TITLE
feat: add XDG_CONFIG_HOME to Firefox profile search paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -336,6 +336,7 @@ multiselect() {
 #== Profile Dir ================================================================
 firefoxProfileDirPaths=(
   "${HOME}/.mozilla/firefox"
+  "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox"
   "${HOME}/.waterfox"
   "${HOME}/.librewolf"
   "${HOME}/.ghostery browser"


### PR DESCRIPTION
**Describe the PR**
Firefox (as of v147) now supports the XDG Base Directory Specification. This change ensures the script detects profiles located in $XDG_CONFIG_HOME/mozilla/firefox, falling back to $HOME/.config if the variable is unset.

This prevents the script from missing profiles on modern Linux installations that have migrated away from the traditional $HOME/.mozilla/ directory.

**PR Type**
<!-- Check like `- [x]`. -->

- [x] `Add:` Add feature or enhanced.
- [ ] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
Previously the script would exit with `FAILED: Unable to find firefox profile dir.` in systems following XDG Base Specification.
```sh
$ bash -c "$(curl -fsSL https://raw.githubusercontent.com/black7375/Firefox-UI-Fix/master/install.sh)"
Checked install type: Network....................OK
1) Original(default)
2) Photon-Style
3) Proton-Style
4) Update
#? 1
Selected Original(default).......................OK
FAILED: Unable to find firefox profile dir.
```