### PR TITLE
install.ps1: Force cast on lists

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -401,11 +401,11 @@ function Check-ProfileDir() {
   )
 
   if ( "${profileDir}" -ne "" ) {
-    $global:firefoxProfileDirPaths = @("${profileDir}")
+    [System.Collections.Generic.List[string]]$global:firefoxProfileDirPaths = @("${profileDir}")
   }
 
 
-  $global:firefoxProfileDirPaths = Filter-Path $global:firefoxProfileDirPaths "Container"
+  [System.Collections.Generic.List[string]]$global:firefoxProfileDirPaths = Filter-Path $global:firefoxProfileDirPaths "Container"
 
   if ( $firefoxProfileDirPaths.Length -eq 0 ) {
     Lepton-ErrorMessage "Unable to find firefox profile dir."
@@ -653,7 +653,7 @@ $localCustomFiles = $customFiles.Clone()
 
 $customFileExist = $false
 function Check-CustomFiles() {
-  $global:localCustomFiles = Filter-Path $localCustomFiles
+  [System.Collections.Generic.List[string]]$global:localCustomFiles = Filter-Path $localCustomFiles
 
   if ( $global:localCustomFiles.Length -gt 0 ) {
     $global:customFileExist = $true


### PR DESCRIPTION
**Describe the PR**
This fixes an issue that when running the install script to update per the README, it creates a folder called C in the current directory. This is due to Powershell's bizarre folding of single-item arrays into an item; the first item of `$firefoxProfileDirPaths` ([L520](https://github.com/black7375/Firefox-UI-Fix/blob/1f30fe71dd5afd80cb803753eedef50f71dee9a5/install.ps1#L520)) is therefore misread not as a whole path, but as the first character: `C`.

I also added the cast to `$global:localCustomFiles`, in case the same issue occurs on return from `Filter-Path`.

**PR Type**

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->
None found
