### PR TITLE
Fix unrounded <audio> element due to --media-background property

### DIFF
--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -85,8 +85,9 @@
 @media -moz-pref("userContent.player.ui") {
   audio {
     --duration-color: #929292; /* Like Original */
-    background: rgba(26, 26, 26, 0.8); /* Like Original */
-    border-radius: 8px;
+    --media-background: rgba(26, 26, 26, 0.8); /* Like Original */
+    border-radius: 8px !important;
+    overflow: clip !important;
     --box-shadow1: rgba(14, 13, 26, 0.12);
     --box-shadow2: rgba(7, 48, 114, 0.12);
     --box-shadow3: rgba(34, 0, 51, 0.04);
@@ -3830,7 +3831,8 @@
   audio {
     --duration-color: #929292; /* Like Original */
     --media-background: rgba(26, 26, 26, 0.8); /* Like Original */
-    border-radius: 8px;
+    border-radius: 8px !important;
+    overflow: clip !important;
     --box-shadow1: rgba(14, 13, 26, 0.12);
     --box-shadow2: rgba(7, 48, 114, 0.12);
     --box-shadow3: rgba(34, 0, 51, 0.04);

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -85,7 +85,7 @@
 @media -moz-pref("userContent.player.ui") {
   audio {
     --duration-color: #929292; /* Like Original */
-    --media-background: rgba(26, 26, 26, 0.8); /* Like Original */
+    background: rgba(26, 26, 26, 0.8); /* Like Original */
     border-radius: 8px;
     --box-shadow1: rgba(14, 13, 26, 0.12);
     --box-shadow2: rgba(7, 48, 114, 0.12);

--- a/css/leptonContentESR.css
+++ b/css/leptonContentESR.css
@@ -85,8 +85,9 @@
 @supports -moz-bool-pref("userContent.player.ui") {
   audio {
     --duration-color: #929292; /* Like Original */
-    background: rgba(26, 26, 26, 0.8); /* Like Original */
-    border-radius: 8px;
+    --media-background: rgba(26, 26, 26, 0.8); /* Like Original */
+    border-radius: 8px !important;
+    overflow: clip !important;
     --box-shadow1: rgba(14, 13, 26, 0.12);
     --box-shadow2: rgba(7, 48, 114, 0.12);
     --box-shadow3: rgba(34, 0, 51, 0.04);

--- a/css/leptonContentESR.css
+++ b/css/leptonContentESR.css
@@ -85,7 +85,7 @@
 @supports -moz-bool-pref("userContent.player.ui") {
   audio {
     --duration-color: #929292; /* Like Original */
-    --media-background: rgba(26, 26, 26, 0.8); /* Like Original */
+    background: rgba(26, 26, 26, 0.8); /* Like Original */
     border-radius: 8px;
     --box-shadow1: rgba(14, 13, 26, 0.12);
     --box-shadow2: rgba(7, 48, 114, 0.12);

--- a/src/contents/_video_player.scss
+++ b/src/contents/_video_player.scss
@@ -34,7 +34,8 @@
     --duration-color: #929292; /* Like Original */
     --media-background: rgba(26,26,26,.8); /* Like Original */
 
-    border-radius: 8px;
+    border-radius: 8px !important;
+    overflow: clip !important;
     --box-shadow1: rgba(14,13,26,.12);
     --box-shadow2: rgba(7,48,114,.12);
     --box-shadow3: rgba(34,0,51,.04);


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->
Setting the `--media-background` variable causes `<audio>` elements to appear square instead of having rounded corners as the `border-radius` property indicates. Changing it to `background` resolves this, altering the element's background while still keeping the corners rounded.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Screenshot of Change Results**
<!-- If applicable, add screenshots to help explain your commit. -->
<img width="2880" height="1645" alt="image" src="https://github.com/user-attachments/assets/255affbe-cc88-4764-9f34-eeef4303c916" />