### PR TITLE
Fix/firefox esr profiles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -393,7 +393,7 @@ check_profile_ini() {
 
   local foundCount="${#firefoxProfileDirPaths[@]}"
   if [ "${foundCount}" -eq 0 ]; then
-    lepton_error_message "Unable to find ${PROFILEINFOFILE}"
+    lepton_error_message "No profile with ${PROFILEINFOFILE} was found in any directory."
   fi
 
   lepton_ok_message "Profiles info file found"

--- a/install.sh
+++ b/install.sh
@@ -336,6 +336,7 @@ multiselect() {
 #== Profile Dir ================================================================
 firefoxProfileDirPaths=(
   "${HOME}/.mozilla/firefox"
+  "${HOME}/.mozilla/firefox-esr"
   "${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox"
   "${HOME}/.waterfox"
   "${HOME}/.librewolf"
@@ -376,11 +377,18 @@ check_profile_dir() {
 #== Profile Info ===============================================================
 PROFILEINFOFILE="profiles.ini"
 check_profile_ini() {
+  local foundDirs=()
   for profileDir in "${firefoxProfileDirPaths[@]}"; do
-    if [ ! -f "${profileDir}/${PROFILEINFOFILE}" ]; then
-      lepton_error_message "Unable to find ${PROFILEINFOFILE} at ${profileDir}"
+    if [ -f "${profileDir}/${PROFILEINFOFILE}" ]; then
+      foundDirs+=("${profileDir}")
     fi
   done
+  firefoxProfileDirPaths=("${foundDirs[@]}")
+
+  local foundCount="${#firefoxProfileDirPaths[@]}"
+  if [ "${foundCount}" -eq 0 ]; then
+    lepton_error_message "Unable to find ${PROFILEINFOFILE}"
+  fi
 
   lepton_ok_message "Profiles info file found"
 }

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,10 @@ lepton_error_message() {
   exit 1
 }
 
+lepton_warn_message() {
+  >&2 echo "WARNING: ${@}"
+}
+
 lepton_ok_message() {
   local SIZE=50
   local FILLED=""
@@ -381,6 +385,8 @@ check_profile_ini() {
   for profileDir in "${firefoxProfileDirPaths[@]}"; do
     if [ -f "${profileDir}/${PROFILEINFOFILE}" ]; then
       foundDirs+=("${profileDir}")
+    else
+      lepton_warn_message "Skipping ${profileDir} (no ${PROFILEINFOFILE})"
     fi
   done
   firefoxProfileDirPaths=("${foundDirs[@]}")


### PR DESCRIPTION
**Describe the PR**

`install.sh` failed on a fresh Kubuntu (KDE Plasma 6.x) install with **firefox-esr**:

```
FAILED: Unable to find profiles.ini at /home/<user>/.var/app/io.gitlab.librewolf-community/.librewolf
```

There is no Flatpak and no LibreWolf on the machine, yet the script aborts pointing at a LibreWolf path. Two independent problems cause this:

1. **firefox-esr profile dir was not in the candidate list.** On Debian/Ubuntu the `firefox-esr` package stores its profile in `~/.mozilla/firefox-esr/` (not `~/.mozilla/firefox/`), so the profile was never found.

2. **`check_profile_ini` aborted on the first existing candidate dir without `profiles.ini`.** It required *every* existing candidate dir to contain `profiles.ini` and `exit 1`-ed on the first one that didn't — even though a perfectly valid profile dir was also present.

**Why that LibreWolf dir exists without Flatpak**

On KDE Plasma 6.x, `plasma-browser-integration` ships a `flatpak-integrator` component (the "Plasma Browser Integration Flatpak Integration" background service) that pre-creates native-messaging-host directories for a hardcoded list of Flatpak browsers — **even when neither Flatpak nor that browser is installed**. The browser list and target path come straight from its source ([`flatpak-integrator/plugin.cpp`](https://github.com/KDE/plasma-browser-integration/blob/master/flatpak-integrator/plugin.cpp#L142)):

```cpp
{BrowserBase::Firefox, u"org.mozilla.firefox"_s,           u"/.mozilla/native-messaging-hosts"_s},
{BrowserBase::Firefox, u"io.gitlab.librewolf-community"_s, u"/.librewolf/native-messaging-hosts"_s},
// path: QDir::homePath() + "/.var/app/" + browser.id
// comment: "always create integration regardless of the browser being installed
//           so we can be ready for if it is installed"
```

So `~/.var/app/io.gitlab.librewolf-community/.librewolf/` is created as an empty stub (no `profiles.ini`). It passes the existing `-d` filter in `check_profile_dir`, then aborts `check_profile_ini`. This component is new in Plasma 6.x (Debian/Ubuntu `plasma-browser-integration` ~6.3.x); Plasma 5.27 is unaffected, which is why this surfaces on recent KDE distros.

**Changes**

- Add `~/.mozilla/firefox-esr` to `firefoxProfileDirPaths`.
- Make `check_profile_ini` tolerant: keep only the dirs that actually contain `profiles.ini`, and error out only when *none* do. Dirs without `profiles.ini` (e.g. the KDE stub) are now skipped instead of being fatal, and each skip is logged via a new non-fatal `lepton_warn_message` so the behavior is visible:
  ```
  WARNING: Skipping /home/<user>/.var/app/io.gitlab.librewolf-community/.librewolf (no profiles.ini)
  ```
- Downstream functions benefit too, since they iterate over the cleaned-up list.

No behavior change for setups that already worked: a single valid profile dir still passes exactly as before.

**PR Type**

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!-- Add an issue number here if there is one, otherwise leave blank. -->

**Screenshots**

Not applicable (install script change).

**Additional context**

Reproduction: fresh Kubuntu with the default Plasma 6.x desktop (`plasma-browser-integration` installed) + `firefox-esr`, no Flatpak. Tested on a real system — install now detects `~/.mozilla/firefox-esr`, skips the empty KDE stub dir with a warning, and applies the theme correctly.

References:
- KDE source creating the stub dirs: https://github.com/KDE/plasma-browser-integration/blob/master/flatpak-integrator/plugin.cpp
- Independent user report (Flatpak not installed): https://bbs.archlinux.org/viewtopic.php?id=303514