### PR TITLE
Add toolbarbutton padding utilties to translate between latest & esr variable names

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -4287,7 +4287,7 @@
   /* Tabbar Buttons */
   :root {
     --newtab-button-minus-width-padding: 2px;
-    --newtab-button-width-padding: calc(var(--toolbarbutton-inner-padding) - var(--newtab-button-minus-width-padding));
+    --newtab-button-width-padding: calc(var(--toolbarbutton-padding-inner) - var(--newtab-button-minus-width-padding));
   }
   #widget-overflow-mainView #new-tab-button,
   #widget-overflow-mainView #alltabs-button {
@@ -4295,7 +4295,7 @@
   }
   #new-tab-button > .toolbarbutton-icon,
   #alltabs-button > .toolbarbutton-badge-stack {
-    /* Original: calc(2 * var(--toolbarbutton-inner-padding) + 16px) */
+    /* Original: calc(2 * var(--toolbarbutton-padding-inner) + 16px) */
     width: calc(2 * var(--newtab-button-width-padding) + 16px) !important;
     /* Original: --toolbarbutton-inner-padding */
     padding-left: var(--newtab-button-width-padding) !important;
@@ -4330,7 +4330,8 @@
   }
   :root:not([uidensity="touch"]) #new-tab-button,
   #alltabs-button {
-    --toolbarbutton-outer-padding: 1px; /* Original: 2px*/
+    --toolbarbutton-padding-outer: 1px;
+    /* Original: 2px*/
   }
   /* Tab - Max Size */
   @media not -moz-pref("userChrome.tab.photon_like_padding") {
@@ -4509,9 +4510,8 @@
       ) !important;
     }
     #TabsToolbar {
-      --toolbarbutton-inner-padding: calc(
-        (var(--tab-min-height) - 18px) / 2
-      ) !important; /* Prevent overflow pinned tab bottom margin */
+      --toolbarbutton-padding-inner: calc((var(--tab-min-height) - 18px) / 2) !important;
+      /* Prevent overflow pinned tab bottom margin */
     }
     @media not -moz-pref("userChrome.tabbar.multi_row") {
       :root:not([uidensity="compact"]) #TabsToolbar:not([multibar]) #pinned-tabs-container,
@@ -4551,10 +4551,10 @@
   }
   #scrollbutton-up,
   #scrollbutton-down {
-    /* Original: var(--toolbarbutton-inner-padding) calc(var(--toolbarbutton-inner-padding) - 6px) = 9px */
+    /* Original: var(--toolbarbutton-padding-inner) calc(var(--toolbarbutton-padding-inner) - 6px) = 9px */
     /* https://github.com/mozilla/gecko-dev/blob/71b1259afd1cdaf41871ae675c2dadb967ea5b34/browser/themes/shared/toolbarbuttons.inc.css#L142 */
-    padding-top: var(--scrollbtn-vertical-padding, var(--toolbarbutton-inner-padding)) !important;
-    padding-bottom: var(--scrollbtn-vertical-padding, var(--toolbarbutton-inner-padding)) !important;
+    padding-top: var(--scrollbtn-vertical-padding, var(--toolbarbutton-padding-inner)) !important;
+    padding-bottom: var(--scrollbtn-vertical-padding, var(--toolbarbutton-padding-inner)) !important;
     /* Original: 4px */
     border-top-width: var(--scrollbtn-vertical-border, 4px) !important;
     border-bottom-width: var(--scrollbtn-vertical-border, 4px) !important;
@@ -4584,11 +4584,12 @@
 }
 @media -moz-pref("userChrome.padding.toolbar_button") {
   :root[uidensity="compact"] {
-    --toolbarbutton-outer-padding: 2px !important; /* Original: 3px, General is 2px */
+    --toolbarbutton-padding-outer: 2px !important;
+    /* Original: 3px, General is 2px */
   }
   @media -moz-pref("userChrome.padding.toolbar_button.compact") {
     :root {
-      --toolbarbutton-inner-padding: var(--uc-small-toolbarbutton-inner-padding) !important;
+      --toolbarbutton-padding-inner: var(--uc-small-toolbarbutton-inner-padding) !important;
     }
   }
 }
@@ -5072,7 +5073,7 @@
         min-width: var(--uc-window-drag-space-post);
       }
       #toolbar-menubar .toolbarbutton-1 {
-        --toolbarbutton-inner-padding: 3px;
+        --toolbarbutton-padding-inner: 3px;
       }
       :root:not([chromehidden~="menubar"], [sizemode="fullscreen"])
         #toolbar-menubar:not([autohide="true"])
@@ -5186,7 +5187,7 @@
             min-width: var(--uc-window-drag-space-post);
           }
           #toolbar-menubar .toolbarbutton-1 {
-            --toolbarbutton-inner-padding: 3px;
+            --toolbarbutton-padding-inner: 3px;
           }
           :root:not([chromehidden~="menubar"], [sizemode="fullscreen"])
             #toolbar-menubar:not([autohide="true"])
@@ -5249,7 +5250,8 @@
         --uc-navbar-block: 3px;
       }
       #nav-bar {
-        --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+        --toolbarbutton-padding-inner: 6px;
+        /* Original: 8px */
         border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
       }
       #nav-bar,
@@ -5273,11 +5275,11 @@
     }
     #urlbar-container {
       min-width: calc(
-        var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-inner-padding)
+        var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-padding-inner)
       ) !important;
     }
     #urlbar[breakout][breakout-extend] {
-      min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-inner-padding))) !important;
+      min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-padding-inner))) !important;
     }
     #PersonalToolbar {
       position: relative;
@@ -5353,7 +5355,8 @@
           --uc-navbar-block: 3px;
         }
         #nav-bar {
-          --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+          --toolbarbutton-padding-inner: 6px;
+          /* Original: 8px */
           border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
         }
         #nav-bar,
@@ -5377,11 +5380,11 @@
       }
       #urlbar-container {
         min-width: calc(
-          var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-inner-padding)
+          var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-padding-inner)
         ) !important;
       }
       #urlbar[breakout][breakout-extend] {
-        min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-inner-padding))) !important;
+        min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-padding-inner))) !important;
       }
       #PersonalToolbar {
         position: relative;
@@ -7049,7 +7052,7 @@
   #tabbrowser-tabs[closebuttons="activetab"][hasadjacentnewtabbutton="true"] #pinned-tabs-container,
   #tabbrowser-tabs[closebuttons="activetab"][hasadjacentnewtabbutton="true"] #tabbrowser-arrowscrollbox {
     padding-inline-end: calc(
-      16px + (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding)) * 2
+      16px + (var(--toolbarbutton-padding-inner) + var(--toolbarbutton-padding-outer)) * 2
     ) !important;
   }
 }
@@ -8055,7 +8058,7 @@
       }
     }
     #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button::before {
-      left: calc(50% - (8px + var(--toolbarbutton-inner-padding)));
+      left: calc(50% - (8px + var(--toolbarbutton-padding-inner)));
     }
   }
   @media not -moz-pref("userChrome.tab.newtab_button_like_tab") {
@@ -8404,7 +8407,7 @@
       }
       @media -moz-pref("userChrome.tab.bottom_rounded_corner.chrome") or -moz-pref("userChrome.tab.bottom_rounded_corner.edge") {
         #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button {
-          --uc-newtab-non-corner-bgwidth: calc(2 * var(--toolbarbutton-inner-padding));
+          --uc-newtab-non-corner-bgwidth: calc(2 * var(--toolbarbutton-padding-inner));
         }
       }
     }
@@ -8533,8 +8536,8 @@
   /* '+'Icon */
   #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button .toolbarbutton-icon {
     border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0 !important; /* Original: var(--tab-border-radius) */
-    padding: calc(var(--toolbarbutton-inner-padding) - var(--tab-block-margin) / 4) var(--toolbarbutton-inner-padding)
-      calc(var(--toolbarbutton-inner-padding) + var(--tab-block-margin) / 4 + var(--uc-tabs-navbar-shadow-size)) !important;
+    padding: calc(var(--toolbarbutton-padding-inner) - (var(--tab-block-margin) / 4)) var(--toolbarbutton-padding-inner)
+      calc(var(--toolbarbutton-padding-inner) + (var(--tab-block-margin) / 4) + var(--uc-tabs-navbar-shadow-size)) !important;
     -moz-context-properties: fill, fill-opacity;
     fill: var(--toolbarbutton-icon-fill);
     fill-opacity: var(--toolbarbutton-icon-fill-opacity);
@@ -8561,13 +8564,13 @@
     --tab-border-radius: var(--toolbarbutton-border-radius);
     margin-left: 1px;
     /* Original: calc((var(--tab-min-height) - 16px) / 2) = 10px */
-    --toolbarbutton-inner-padding: var(--uc-small-toolbarbutton-inner-padding);
+    --toolbarbutton-padding-inner: var(--uc-small-toolbarbutton-inner-padding);
   }
 }
 /*= New tab button - Proton like button ======================================*/
 @media -moz-pref("userChrome.tab.newtab_button_proton") {
   :root:not([uidensity="touch"]) #tabs-newtab-button > .toolbarbutton-icon {
-    --toolbarbutton-inner-padding: calc((var(--tab-min-height) - 16px) / 2 - 1px);
+    --toolbarbutton-padding-inner: calc((var(--tab-min-height) - 16px) / 2 - 1px);
   }
 }
 /*= Unloaded Tab - Contents Opacity ===========================================*/
@@ -9295,7 +9298,7 @@
 /*= Nav Bar - Navbar comabine with sidebar===================================*/
 @media -moz-pref("userChrome.navbar.as_sidebar") {
   :root {
-    --uc-navbar-margin-block: var(--toolbarbutton-inner-padding);
+    --uc-navbar-margin-block: var(--toolbarbutton-padding-inner);
     --uc-urlbar-margin-top: calc(var(--uc-navbar-height) + var(--uc-navbar-margin-block));
     --uc-urlbar-container-height: 36px;
     --uc-navbar-sideblock-height: calc(var(--uc-urlbar-margin-top) + var(--uc-urlbar-container-height));
@@ -9367,7 +9370,7 @@
   }
   #urlbar-container {
     top: var(--uc-urlbar-margin-top);
-    min-width: calc(var(--uc-sidebar-activate-width) - 2 * var(--toolbarbutton-inner-padding)) !important;
+    min-width: calc(var(--uc-sidebar-activate-width) - (2 * var(--toolbarbutton-padding-inner))) !important;
     margin-inline: auto !important; /* Original: var(--urlbar-margin-inline) */
     left: 50%;
     transform: translateX(-50%);
@@ -9516,12 +9519,12 @@
     --uc-searchBar-button-size: 32px;
     --uc-urlView-row-padding: 8px;
     --uc-urlView-row-bottom: 2px;
-    --uc-urlView-margin: calc(var(--uc-sidebar-activate-width, 18rem) + var(--toolbarbutton-inner-padding));
+    --uc-urlView-margin: calc(var(--uc-sidebar-activate-width, 18rem) + var(--toolbarbutton-padding-inner));
     position: fixed !important;
     left: 50vw;
     transform: translateX(-50%);
     top: 12vh !important;
-    width: calc(100vw - (var(--uc-urlView-margin) + var(--toolbarbutton-inner-padding))) !important;
+    width: calc(100vw - (var(--uc-urlView-margin) + var(--toolbarbutton-padding-inner))) !important;
     /* paddding as margin */
     /* background */
     background-color: var(--toolbar-field-focus-background-color) !important;
@@ -9782,7 +9785,7 @@
     --uc-combined-circlebutton-hover-background: var(--uc-combined-circlebutton-background);
     --uc-combined-circlebutton-active-background: var(--toolbarbutton-active-background);
     --uc-combined-circlebutton-border-color: hsla(240, 5%, 5%, 0.3);
-    --uc-toolbarbutton-boundary: calc(var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding));
+    --uc-toolbarbutton-boundary: calc(var(--toolbarbutton-padding-outer) + var(--toolbarbutton-padding-inner));
     --uc-toolbarbutton-padding: calc(2 * var(--uc-toolbarbutton-boundary));
     --uc-toolbarbutton-size: calc(12px + var(--uc-toolbarbutton-padding));
     --uc-toolbarbutton-halfsize: calc(6px + var(--uc-toolbarbutton-boundary));
@@ -9859,13 +9862,13 @@
       position: relative;
     }
     #nav-bar-customization-target > #forward-button > .toolbarbutton-icon {
-      padding-inline-end: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-inner-padding) */
+      padding-inline-end: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-padding-inner) */
       padding-block: var(--urlbar-icon-padding) !important;
       height: var(--uc-urlbar-icon-size) !important;
     }
     @media -moz-pref("userChrome.combined.urlbar.nav_button") {
       #nav-bar-customization-target > #forward-button {
-        padding-inline-end: 0px !important; /* Original: var(--toolbarbutton-outer-padding) */
+        padding-inline-end: 0px !important; /* Original: var(--toolbarbutton-padding-outer) */
       }
     }
     @media not -moz-pref("userChrome.combined.urlbar.nav_button") {
@@ -10011,7 +10014,7 @@
         }
       }
       #nav-bar-customization-target > #back-button > .toolbarbutton-icon {
-        padding-inline-start: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-inner-padding) */
+        padding-inline-start: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-padding-inner) */
         padding-block: var(--urlbar-icon-padding) !important;
         height: var(--uc-urlbar-icon-size) !important;
       }
@@ -10030,7 +10033,7 @@
         @media -moz-pref("userChrome.padding.toolbar_button") {
           @media -moz-pref("userChrome.padding.toolbar_button.compact") {
             #nav-bar-customization-target > #back-button {
-              --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+              --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
             }
           }
         }
@@ -10044,7 +10047,7 @@
             padding-inline-end: 0 !important;
           }
           #nav-bar-customization-target > #back-button[disabled="true"] {
-            padding-inline-end: calc(var(--toolbarbutton-outer-padding) + 1px) !important;
+            padding-inline-end: calc(var(--toolbarbutton-padding-outer) + 1px) !important;
           }
         }
         #nav-bar-customization-target > #back-button > menupopup {
@@ -10071,7 +10074,7 @@
       @media -moz-pref("userChrome.padding.toolbar_button") {
         @media -moz-pref("userChrome.padding.toolbar_button.compact") {
           #nav-bar-customization-target > #back-button {
-            --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+            --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
           }
         }
       }
@@ -10085,7 +10088,7 @@
           padding-inline-end: 0 !important;
         }
         #nav-bar-customization-target > #back-button[disabled="true"] {
-          padding-inline-end: calc(var(--toolbarbutton-outer-padding) + 1px) !important;
+          padding-inline-end: calc(var(--toolbarbutton-padding-outer) + 1px) !important;
         }
       }
       #nav-bar-customization-target > #back-button > menupopup {
@@ -10116,7 +10119,7 @@
     @media -moz-pref("userChrome.padding.toolbar_button") {
       @media -moz-pref("userChrome.padding.toolbar_button.compact") {
         #nav-bar-customization-target > #home-button {
-          --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+          --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
         }
       }
     }
@@ -10202,7 +10205,7 @@
   @media -moz-pref("userChrome.padding.toolbar_button") {
     @media -moz-pref("userChrome.padding.toolbar_button.compact") {
       #nav-bar-customization-target > #home-button {
-        --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+        --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
       }
     }
   }
@@ -10410,7 +10413,7 @@
       var(--uc-rounding-toolbar, var(--toolbarbutton-border-radius)) !important;
   }
   .findbar-container > .findbar-find-fast {
-    padding: var(--toolbarbutton-inner-padding) 1px;
+    padding: var(--toolbarbutton-padding-inner) 1px;
     margin: 0 !important;
   }
   .findbar-container > .findbar-find-status {
@@ -10547,7 +10550,7 @@
 @media -moz-pref("userChrome.autohide.back_button") or -moz-pref("userChrome.autohide.forward_button") {
   :root {
     --uc-toolbarbutton-hide-size: calc(
-      -1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding))))
+      -1 * (16px + (2 * (var(--toolbarbutton-padding-outer) + var(--toolbarbutton-padding-inner))))
     );
   }
 }
@@ -10673,7 +10676,7 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
     --uc-navbar-height: var(--uc-navbar-height-default);
     --uc-navbar-height-default: calc(
-      16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding))
+      16px + 2 * (var(--toolbarbutton-padding-inner) + var(--toolbarbutton-padding-outer))
     );
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
     --uc-bm-height: var(--uc-bm-height-default);
@@ -19197,7 +19200,7 @@
 @media (-moz-bool-pref: "userChrome.padding.tabbar_width") {
   :root {
     --newtab-button-minus-width-padding: 2px;
-    --newtab-button-width-padding: calc(var(--toolbarbutton-inner-padding) - var(--newtab-button-minus-width-padding));
+    --newtab-button-width-padding: calc(var(--toolbarbutton-padding-inner) - var(--newtab-button-minus-width-padding));
   }
 }
 @media (-moz-bool-pref: "userChrome.padding.tabbar_width") {
@@ -19209,7 +19212,7 @@
 @media (-moz-bool-pref: "userChrome.padding.tabbar_width") {
   #new-tab-button > .toolbarbutton-icon,
   #alltabs-button > .toolbarbutton-badge-stack {
-    /* Original: calc(2 * var(--toolbarbutton-inner-padding) + 16px) */
+    /* Original: calc(2 * var(--toolbarbutton-padding-inner) + 16px) */
     width: calc(2 * var(--newtab-button-width-padding) + 16px) !important;
     /* Original: --toolbarbutton-inner-padding */
     padding-left: var(--newtab-button-width-padding) !important;
@@ -19252,7 +19255,8 @@
 @media (-moz-bool-pref: "userChrome.padding.tabbar_width") {
   :root:not([uidensity="touch"]) #new-tab-button,
   #alltabs-button {
-    --toolbarbutton-outer-padding: 1px; /* Original: 2px*/
+    --toolbarbutton-padding-outer: 1px;
+    /* Original: 2px*/
   }
 }
 @media (-moz-bool-pref: "userChrome.padding.tabbar_width") and (not (-moz-bool-pref: "userChrome.tab.photon_like_padding")) {
@@ -19435,9 +19439,8 @@
     ) !important;
   }
   #TabsToolbar {
-    --toolbarbutton-inner-padding: calc(
-      (var(--tab-min-height) - 18px) / 2
-    ) !important; /* Prevent overflow pinned tab bottom margin */
+    --toolbarbutton-padding-inner: calc((var(--tab-min-height) - 18px) / 2) !important;
+    /* Prevent overflow pinned tab bottom margin */
   }
 }
 @media (-moz-bool-pref: "userChrome.padding.tabbar_height") and (-moz-bool-pref: "userChrome.tab.connect_to_window") and (not (-moz-bool-pref: "userChrome.tabbar.multi_row")) {
@@ -19473,10 +19476,10 @@
 @media (-moz-bool-pref: "userChrome.padding.tabbar_height") {
   #scrollbutton-up,
   #scrollbutton-down {
-    /* Original: var(--toolbarbutton-inner-padding) calc(var(--toolbarbutton-inner-padding) - 6px) = 9px */
+    /* Original: var(--toolbarbutton-padding-inner) calc(var(--toolbarbutton-padding-inner) - 6px) = 9px */
     /* https://github.com/mozilla/gecko-dev/blob/71b1259afd1cdaf41871ae675c2dadb967ea5b34/browser/themes/shared/toolbarbuttons.inc.css#L142 */
-    padding-top: var(--scrollbtn-vertical-padding, var(--toolbarbutton-inner-padding)) !important;
-    padding-bottom: var(--scrollbtn-vertical-padding, var(--toolbarbutton-inner-padding)) !important;
+    padding-top: var(--scrollbtn-vertical-padding, var(--toolbarbutton-padding-inner)) !important;
+    padding-bottom: var(--scrollbtn-vertical-padding, var(--toolbarbutton-padding-inner)) !important;
     /* Original: 4px */
     border-top-width: var(--scrollbtn-vertical-border, 4px) !important;
     border-bottom-width: var(--scrollbtn-vertical-border, 4px) !important;
@@ -19508,12 +19511,13 @@
 }
 @media (-moz-bool-pref: "userChrome.padding.toolbar_button") {
   :root[uidensity="compact"] {
-    --toolbarbutton-outer-padding: 2px !important; /* Original: 3px, General is 2px */
+    --toolbarbutton-padding-outer: 2px !important;
+    /* Original: 3px, General is 2px */
   }
 }
 @media (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact") {
   :root {
-    --toolbarbutton-inner-padding: var(--uc-small-toolbarbutton-inner-padding) !important;
+    --toolbarbutton-padding-inner: var(--uc-small-toolbarbutton-inner-padding) !important;
   }
 }
 /*= Nav Bar - Reduce Width ===================================================*/
@@ -20000,7 +20004,7 @@
     min-width: var(--uc-window-drag-space-post);
   }
   #toolbar-menubar .toolbarbutton-1 {
-    --toolbarbutton-inner-padding: 3px;
+    --toolbarbutton-padding-inner: 3px;
   }
   :root:not([chromehidden~="menubar"], [sizemode="fullscreen"])
     #toolbar-menubar:not([autohide="true"])
@@ -20108,7 +20112,7 @@
     min-width: var(--uc-window-drag-space-post);
   }
   #toolbar-menubar .toolbarbutton-1 {
-    --toolbarbutton-inner-padding: 3px;
+    --toolbarbutton-padding-inner: 3px;
   }
   :root:not([chromehidden~="menubar"], [sizemode="fullscreen"])
     #toolbar-menubar:not([autohide="true"])
@@ -20175,7 +20179,8 @@
     --uc-navbar-block: 3px;
   }
   #nav-bar {
-    --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+    --toolbarbutton-padding-inner: 6px;
+    /* Original: 8px */
     border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
   }
   #nav-bar,
@@ -20200,13 +20205,13 @@
 @media (-moz-bool-pref: "userChrome.tabbar.one_liner") and (not (-moz-bool-pref: "userChrome.tabbar.one_liner.responsive")) {
   #urlbar-container {
     min-width: calc(
-      var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-inner-padding)
+      var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-padding-inner)
     ) !important;
   }
 }
 @media (-moz-bool-pref: "userChrome.tabbar.one_liner") and (not (-moz-bool-pref: "userChrome.tabbar.one_liner.responsive")) {
   #urlbar[breakout][breakout-extend] {
-    min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-inner-padding))) !important;
+    min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-padding-inner))) !important;
   }
 }
 @media (-moz-bool-pref: "userChrome.tabbar.one_liner") and (not (-moz-bool-pref: "userChrome.tabbar.one_liner.responsive")) {
@@ -20294,7 +20299,8 @@
     --uc-navbar-block: 3px;
   }
   #nav-bar {
-    --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+    --toolbarbutton-padding-inner: 6px;
+    /* Original: 8px */
     border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
   }
   #nav-bar,
@@ -20319,13 +20325,13 @@
 @media screen and (-moz-bool-pref: "userChrome.tabbar.one_liner") and (-moz-bool-pref: "userChrome.tabbar.one_liner.responsive") and (min-width: 1100px) {
   #urlbar-container {
     min-width: calc(
-      var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-inner-padding)
+      var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-padding-inner)
     ) !important;
   }
 }
 @media screen and (-moz-bool-pref: "userChrome.tabbar.one_liner") and (-moz-bool-pref: "userChrome.tabbar.one_liner.responsive") and (min-width: 1100px) {
   #urlbar[breakout][breakout-extend] {
-    min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-inner-padding))) !important;
+    min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-padding-inner))) !important;
   }
 }
 @media screen and (-moz-bool-pref: "userChrome.tabbar.one_liner") and (-moz-bool-pref: "userChrome.tabbar.one_liner.responsive") and (min-width: 1100px) {
@@ -22395,7 +22401,7 @@
   #tabbrowser-tabs[closebuttons="activetab"][hasadjacentnewtabbutton="true"] #pinned-tabs-container,
   #tabbrowser-tabs[closebuttons="activetab"][hasadjacentnewtabbutton="true"] #tabbrowser-arrowscrollbox {
     padding-inline-end: calc(
-      16px + (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding)) * 2
+      16px + (var(--toolbarbutton-padding-inner) + var(--toolbarbutton-padding-outer)) * 2
     ) !important;
   }
 }
@@ -23547,7 +23553,7 @@
 }
 @media (-moz-bool-pref: "userChrome.tab.dynamic_separator") and (-moz-bool-pref: "userChrome.tab.newtab_button_like_tab") {
   #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button::before {
-    left: calc(50% - (8px + var(--toolbarbutton-inner-padding)));
+    left: calc(50% - (8px + var(--toolbarbutton-padding-inner)));
   }
 }
 @media (-moz-bool-pref: "userChrome.tab.dynamic_separator") and (not (-moz-bool-pref: "userChrome.tab.newtab_button_like_tab")) {
@@ -23919,7 +23925,7 @@
   (-moz-bool-pref: "userChrome.tab.newtab_button_like_tab") and (-moz-bool-pref: "userChrome.tab.bottom_rounded_corner") and (-moz-bool-pref: "userChrome.tab.bottom_rounded_corner.edge") and (-moz-bool-pref: "userChrome.tab.bottom_rounded_corner.chrome"),
   (-moz-bool-pref: "userChrome.tab.newtab_button_like_tab") and (-moz-bool-pref: "userChrome.tab.bottom_rounded_corner") and (-moz-bool-pref: "userChrome.tab.bottom_rounded_corner.edge") and (-moz-bool-pref: "userChrome.tab.bottom_rounded_corner.edge") {
   #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button {
-    --uc-newtab-non-corner-bgwidth: calc(2 * var(--toolbarbutton-inner-padding));
+    --uc-newtab-non-corner-bgwidth: calc(2 * var(--toolbarbutton-padding-inner));
   }
 }
 @media (-moz-bool-pref: "userChrome.tab.newtab_button_like_tab") {
@@ -24047,8 +24053,8 @@
 @media (-moz-bool-pref: "userChrome.tab.newtab_button_like_tab") {
   #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button .toolbarbutton-icon {
     border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0 !important; /* Original: var(--tab-border-radius) */
-    padding: calc(var(--toolbarbutton-inner-padding) - var(--tab-block-margin) / 4) var(--toolbarbutton-inner-padding)
-      calc(var(--toolbarbutton-inner-padding) + var(--tab-block-margin) / 4 + var(--uc-tabs-navbar-shadow-size)) !important;
+    padding: calc(var(--toolbarbutton-padding-inner) - (var(--tab-block-margin) / 4)) var(--toolbarbutton-padding-inner)
+      calc(var(--toolbarbutton-padding-inner) + (var(--tab-block-margin) / 4) + var(--uc-tabs-navbar-shadow-size)) !important;
     -moz-context-properties: fill, fill-opacity;
     fill: var(--toolbarbutton-icon-fill);
     fill-opacity: var(--toolbarbutton-icon-fill-opacity);
@@ -24078,13 +24084,13 @@
     --tab-border-radius: var(--toolbarbutton-border-radius);
     margin-left: 1px;
     /* Original: calc((var(--tab-min-height) - 16px) / 2) = 10px */
-    --toolbarbutton-inner-padding: var(--uc-small-toolbarbutton-inner-padding);
+    --toolbarbutton-padding-inner: var(--uc-small-toolbarbutton-inner-padding);
   }
 }
 /*= New tab button - Proton like button ======================================*/
 @media (-moz-bool-pref: "userChrome.tab.newtab_button_proton") {
   :root:not([uidensity="touch"]) #tabs-newtab-button > .toolbarbutton-icon {
-    --toolbarbutton-inner-padding: calc((var(--tab-min-height) - 16px) / 2 - 1px);
+    --toolbarbutton-padding-inner: calc((var(--tab-min-height) - 16px) / 2 - 1px);
   }
 }
 /*= Unloaded Tab - Contents Opacity ===========================================*/
@@ -24855,7 +24861,7 @@
 /*= Nav Bar - Navbar comabine with sidebar===================================*/
 @media (-moz-bool-pref: "userChrome.navbar.as_sidebar") {
   :root {
-    --uc-navbar-margin-block: var(--toolbarbutton-inner-padding);
+    --uc-navbar-margin-block: var(--toolbarbutton-padding-inner);
     --uc-urlbar-margin-top: calc(var(--uc-navbar-height) + var(--uc-navbar-margin-block));
     --uc-urlbar-container-height: 36px;
     --uc-navbar-sideblock-height: calc(var(--uc-urlbar-margin-top) + var(--uc-urlbar-container-height));
@@ -24924,7 +24930,7 @@
 @media (-moz-bool-pref: "userChrome.navbar.as_sidebar") {
   #urlbar-container {
     top: var(--uc-urlbar-margin-top);
-    min-width: calc(var(--uc-sidebar-activate-width) - 2 * var(--toolbarbutton-inner-padding)) !important;
+    min-width: calc(var(--uc-sidebar-activate-width) - (2 * var(--toolbarbutton-padding-inner))) !important;
     margin-inline: auto !important; /* Original: var(--urlbar-margin-inline) */
     left: 50%;
     transform: translateX(-50%);
@@ -25085,12 +25091,12 @@
     --uc-searchBar-button-size: 32px;
     --uc-urlView-row-padding: 8px;
     --uc-urlView-row-bottom: 2px;
-    --uc-urlView-margin: calc(var(--uc-sidebar-activate-width, 18rem) + var(--toolbarbutton-inner-padding));
+    --uc-urlView-margin: calc(var(--uc-sidebar-activate-width, 18rem) + var(--toolbarbutton-padding-inner));
     position: fixed !important;
     left: 50vw;
     transform: translateX(-50%);
     top: 12vh !important;
-    width: calc(100vw - (var(--uc-urlView-margin) + var(--toolbarbutton-inner-padding))) !important;
+    width: calc(100vw - (var(--uc-urlView-margin) + var(--toolbarbutton-padding-inner))) !important;
     /* paddding as margin */
     /* background */
     background-color: var(--toolbar-field-focus-background-color) !important;
@@ -25377,7 +25383,7 @@
     --uc-combined-circlebutton-hover-background: var(--uc-combined-circlebutton-background);
     --uc-combined-circlebutton-active-background: var(--toolbarbutton-active-background);
     --uc-combined-circlebutton-border-color: hsla(240, 5%, 5%, 0.3);
-    --uc-toolbarbutton-boundary: calc(var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding));
+    --uc-toolbarbutton-boundary: calc(var(--toolbarbutton-padding-outer) + var(--toolbarbutton-padding-inner));
     --uc-toolbarbutton-padding: calc(2 * var(--uc-toolbarbutton-boundary));
     --uc-toolbarbutton-size: calc(12px + var(--uc-toolbarbutton-padding));
     --uc-toolbarbutton-halfsize: calc(6px + var(--uc-toolbarbutton-boundary));
@@ -25456,7 +25462,7 @@
     position: relative;
   }
   #nav-bar-customization-target > #forward-button > .toolbarbutton-icon {
-    padding-inline-end: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-inner-padding) */
+    padding-inline-end: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-padding-inner) */
     padding-block: var(--urlbar-icon-padding) !important;
     height: var(--uc-urlbar-icon-size) !important;
   }
@@ -25466,7 +25472,7 @@
   (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button"),
   (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and ((not (-moz-bool-pref: "userChrome.combined.sub_button.as_normal")) or ((-moz-bool-pref: "userChrome.combined.nav_button") and (-moz-bool-pref: "userChrome.combined.urlbar.home_button"))) and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") {
   #nav-bar-customization-target > #forward-button {
-    padding-inline-end: 0px !important; /* Original: var(--toolbarbutton-outer-padding) */
+    padding-inline-end: 0px !important; /* Original: var(--toolbarbutton-padding-outer) */
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.urlbar.nav_button")) and (not (-moz-bool-pref: "userChrome.combined.sub_button.none_background")) and (-moz-bool-pref: "userChrome.combined.urlbar.home_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")),
@@ -25643,7 +25649,7 @@
   (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (-moz-bool-pref: "userChrome.combined.nav_button.home_button") and (not (-moz-bool-pref: "userChrome.combined.sub_button.as_normal")),
   (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (-moz-bool-pref: "userChrome.combined.urlbar.home_button") and (not (-moz-bool-pref: "userChrome.combined.sub_button.as_normal")) {
   #nav-bar-customization-target > #back-button > .toolbarbutton-icon {
-    padding-inline-start: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-inner-padding) */
+    padding-inline-start: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-padding-inner) */
     padding-block: var(--urlbar-icon-padding) !important;
     height: var(--uc-urlbar-icon-size) !important;
   }
@@ -25661,7 +25667,7 @@
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.urlbar.home_button")) and (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact"),
   (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.urlbar.home_button")) and (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact") {
   #nav-bar-customization-target > #back-button {
-    --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+    --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.urlbar.home_button")) and (not (-moz-bool-pref: "userChrome.autohide.back_button")),
@@ -25676,7 +25682,7 @@
     padding-inline-end: 0 !important;
   }
   #nav-bar-customization-target > #back-button[disabled="true"] {
-    padding-inline-end: calc(var(--toolbarbutton-outer-padding) + 1px) !important;
+    padding-inline-end: calc(var(--toolbarbutton-padding-outer) + 1px) !important;
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.urlbar.home_button")),
@@ -25709,7 +25715,7 @@
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (not (-moz-bool-pref: "userChrome.combined.urlbar.nav_button")) and (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact"),
   (-moz-bool-pref: "userChrome.combined.urlbar.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (not (-moz-bool-pref: "userChrome.combined.urlbar.nav_button")) and (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact") {
   #nav-bar-customization-target > #back-button {
-    --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+    --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (not (-moz-bool-pref: "userChrome.combined.urlbar.nav_button")) and (not (-moz-bool-pref: "userChrome.autohide.back_button")),
@@ -25724,7 +25730,7 @@
     padding-inline-end: 0 !important;
   }
   #nav-bar-customization-target > #back-button[disabled="true"] {
-    padding-inline-end: calc(var(--toolbarbutton-outer-padding) + 1px) !important;
+    padding-inline-end: calc(var(--toolbarbutton-padding-outer) + 1px) !important;
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (not (-moz-bool-pref: "userChrome.combined.nav_button.home_button")) and (not (-moz-bool-pref: "userChrome.combined.urlbar.nav_button")),
@@ -25757,7 +25763,7 @@
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (-moz-bool-pref: "userChrome.combined.nav_button.home_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact") {
   #nav-bar-customization-target > #home-button {
-    --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+    --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.nav_button") and (-moz-bool-pref: "userChrome.combined.nav_button.home_button") {
@@ -25850,7 +25856,7 @@
 }
 @media (-moz-bool-pref: "userChrome.combined.urlbar.home_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button") and (-moz-bool-pref: "userChrome.padding.toolbar_button.compact") {
   #nav-bar-customization-target > #home-button {
-    --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+    --toolbarbutton-padding-inner: var(--uc-toolbarbutton-inner-padding-default);
   }
 }
 @media (-moz-bool-pref: "userChrome.combined.urlbar.home_button") {
@@ -26068,7 +26074,7 @@
       var(--uc-rounding-toolbar, var(--toolbarbutton-border-radius)) !important;
   }
   .findbar-container > .findbar-find-fast {
-    padding: var(--toolbarbutton-inner-padding) 1px;
+    padding: var(--toolbarbutton-padding-inner) 1px;
     margin: 0 !important;
   }
   .findbar-container > .findbar-find-status {
@@ -26201,7 +26207,7 @@
 @media (-moz-bool-pref: "userChrome.autohide.back_button"), (-moz-bool-pref: "userChrome.autohide.forward_button") {
   :root {
     --uc-toolbarbutton-hide-size: calc(
-      -1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding))))
+      -1 * (16px + (2 * (var(--toolbarbutton-padding-outer) + var(--toolbarbutton-padding-inner))))
     );
   }
 }
@@ -26329,7 +26335,7 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
     --uc-navbar-height: var(--uc-navbar-height-default);
     --uc-navbar-height-default: calc(
-      16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding))
+      16px + 2 * (var(--toolbarbutton-padding-inner) + var(--toolbarbutton-padding-outer))
     );
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
     --uc-bm-height: var(--uc-bm-height-default);

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -4654,7 +4654,8 @@
   }
   :root:not([uidensity="touch"]) #new-tab-button,
   #alltabs-button {
-    --toolbarbutton-outer-padding: 1px; /* Original: 2px*/
+    --toolbarbutton-outer-padding: 1px;
+    /* Original: 2px*/
   }
   /* Tab - Max Size */
   @supports not -moz-bool-pref("userChrome.tab.photon_like_padding") {
@@ -4855,9 +4856,8 @@
       ) !important;
     }
     #TabsToolbar {
-      --toolbarbutton-inner-padding: calc(
-        (var(--tab-min-height) - 18px) / 2
-      ) !important; /* Prevent overflow pinned tab bottom margin */
+      --toolbarbutton-inner-padding: calc((var(--tab-min-height) - 18px) / 2) !important;
+      /* Prevent overflow pinned tab bottom margin */
     }
     @supports not -moz-bool-pref("userChrome.tabbar.multi_row") {
       :root:not([uidensity="compact"]) #TabsToolbar:not([multibar]) #pinned-tabs-container,
@@ -4930,7 +4930,8 @@
 }
 @supports -moz-bool-pref("userChrome.padding.toolbar_button") {
   :root[uidensity="compact"] {
-    --toolbarbutton-outer-padding: 2px !important; /* Original: 3px, General is 2px */
+    --toolbarbutton-outer-padding: 2px !important;
+    /* Original: 3px, General is 2px */
   }
   @supports -moz-bool-pref("userChrome.padding.toolbar_button.compact") {
     :root {
@@ -5613,7 +5614,8 @@
         --uc-navbar-block: 3px;
       }
       #nav-bar {
-        --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+        --toolbarbutton-inner-padding: 6px;
+        /* Original: 8px */
         border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
       }
       #nav-bar,
@@ -5717,7 +5719,8 @@
           --uc-navbar-block: 3px;
         }
         #nav-bar {
-          --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+          --toolbarbutton-inner-padding: 6px;
+          /* Original: 8px */
           border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
         }
         #nav-bar,
@@ -8989,8 +8992,8 @@
   /* '+'Icon */
   #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button .toolbarbutton-icon {
     border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0 !important; /* Original: var(--tab-border-radius) */
-    padding: calc(var(--toolbarbutton-inner-padding) - var(--tab-block-margin) / 4) var(--toolbarbutton-inner-padding)
-      calc(var(--toolbarbutton-inner-padding) + var(--tab-block-margin) / 4 + var(--uc-tabs-navbar-shadow-size)) !important;
+    padding: calc(var(--toolbarbutton-inner-padding) - (var(--tab-block-margin) / 4)) var(--toolbarbutton-inner-padding)
+      calc(var(--toolbarbutton-inner-padding) + (var(--tab-block-margin) / 4) + var(--uc-tabs-navbar-shadow-size)) !important;
     -moz-context-properties: fill, fill-opacity;
     fill: var(--toolbarbutton-icon-fill);
     fill-opacity: var(--toolbarbutton-icon-fill-opacity);
@@ -9827,7 +9830,7 @@
   }
   #urlbar-container {
     top: var(--uc-urlbar-margin-top);
-    min-width: calc(var(--uc-sidebar-activate-width) - 2 * var(--toolbarbutton-inner-padding)) !important;
+    min-width: calc(var(--uc-sidebar-activate-width) - (2 * var(--toolbarbutton-inner-padding))) !important;
     margin-inline: auto !important; /* Original: var(--urlbar-margin-inline) */
     left: 50%;
     transform: translateX(-50%);

--- a/src/autohide/_common.scss
+++ b/src/autohide/_common.scss
@@ -18,7 +18,7 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
 
     --uc-navbar-height: var(--uc-navbar-height-default);
-    --uc-navbar-height-default: calc(16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding)));
+    --uc-navbar-height-default: calc(16px + 2 * (#{toolbarbutton-padding.inner()} + #{toolbarbutton-padding.outer()}));
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
 
     --uc-bm-height: var(--uc-bm-height-default);

--- a/src/autohide/_index.scss
+++ b/src/autohide/_index.scss
@@ -1,6 +1,6 @@
 @include Option("userChrome.autohide.back_button", "userChrome.autohide.forward_button") {
   :root {
-    --uc-toolbarbutton-hide-size: calc(-1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding)))));
+    --uc-toolbarbutton-hide-size: calc(-1 * (16px + (2 * (#{toolbarbutton-padding.outer()} + #{toolbarbutton-padding.inner()}))));
   }
 }
 

--- a/src/combined/_back_forward_button.scss
+++ b/src/combined/_back_forward_button.scss
@@ -77,13 +77,13 @@
       position: relative;
 
       > .toolbarbutton-icon {
-        padding-inline-end: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-inner-padding) */
+        padding-inline-end: var(--urlbar-icon-padding) !important; /* Original: #{toolbarbutton-padding.inner()} */
         padding-block: var(--urlbar-icon-padding) !important;
         height: var(--uc-urlbar-icon-size) !important;
       }
 
       @include Option("userChrome.combined.urlbar.nav_button") {
-        padding-inline-end: 0px !important; /* Original: var(--toolbarbutton-outer-padding) */
+        padding-inline-end: 0px !important; /* Original: #{toolbarbutton-padding.outer()} */
       }
       @include NotOption("userChrome.combined.urlbar.nav_button") {
         @include NotOption("userChrome.combined.sub_button.none_background") {
@@ -130,7 +130,7 @@
           @include _combined_back_button_background;
         }
         > .toolbarbutton-icon {
-          padding-inline-start: var(--urlbar-icon-padding) !important; /* Original: var(--toolbarbutton-inner-padding) */
+          padding-inline-start: var(--urlbar-icon-padding) !important; /* Original: #{toolbarbutton-padding.inner()} */
           padding-block: var(--urlbar-icon-padding) !important;
           height: var(--uc-urlbar-icon-size) !important;
         }

--- a/src/combined/_combined_circle_button.scss
+++ b/src/combined/_combined_circle_button.scss
@@ -9,7 +9,7 @@
 
   @include Option("userChrome.padding.toolbar_button") {
     @include Option("userChrome.padding.toolbar_button.compact") {
-      --toolbarbutton-inner-padding: var(--uc-toolbarbutton-inner-padding-default);
+      @include toolbarbutton-padding.inner(var(--uc-toolbarbutton-inner-padding-default));
     }
   }
 
@@ -22,7 +22,7 @@
         padding-inline-end: 0 !important;
       }
       &[disabled="true"] {
-        padding-inline-end: calc(var(--toolbarbutton-outer-padding) + 1px) !important;
+        padding-inline-end: calc(#{toolbarbutton-padding.outer()} + 1px) !important;
       }
     }
   }

--- a/src/combined/_index.scss
+++ b/src/combined/_index.scss
@@ -21,7 +21,7 @@
     }
 
     // Padding & Size
-    --uc-toolbarbutton-boundary: calc(var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding));
+    --uc-toolbarbutton-boundary: calc(#{toolbarbutton-padding.outer()} + #{toolbarbutton-padding.inner()});
     --uc-toolbarbutton-padding: calc(2 * var(--uc-toolbarbutton-boundary));
     --uc-toolbarbutton-size: calc(12px + var(--uc-toolbarbutton-padding));
     --uc-toolbarbutton-halfsize: calc(6px + var(--uc-toolbarbutton-boundary));

--- a/src/leptonChrome.scss
+++ b/src/leptonChrome.scss
@@ -11,6 +11,7 @@
 @use "utils/has" as *;
 @use "utils/proton_elements" as Proton;
 @use "utils/mode";
+@use "utils/toolbarbutton-padding";
 @use "sass:selector";
 @use "sass:math";
 

--- a/src/navbar/_as_sidebar.scss
+++ b/src/navbar/_as_sidebar.scss
@@ -1,5 +1,5 @@
 :root {
-  --uc-navbar-margin-block: var(--toolbarbutton-inner-padding);
+  --uc-navbar-margin-block: #{toolbarbutton-padding.inner()};
   --uc-urlbar-margin-top: calc(var(--uc-navbar-height) + var(--uc-navbar-margin-block));
 
   --uc-urlbar-container-height: 36px;
@@ -24,7 +24,7 @@
   @include BoxPack("justify");
 }
 #nav-bar {
-  // --toolbarbutton-outer-padding: 0px !important;
+  // @include toolbarbutton-padding.outer(0px !important);
   z-index: 1;
 
   margin-top: calc(var(--uc-tabbar-height) + var(--uc-bm-height) + var(--uc-menubar-height) + var(--uc-navbar-margin-block)); // drag space
@@ -75,7 +75,7 @@
 
 #urlbar-container {
   top: var(--uc-urlbar-margin-top);
-  min-width: calc(var(--uc-sidebar-activate-width) - (2 * var(--toolbarbutton-inner-padding))) !important;
+  min-width: calc(var(--uc-sidebar-activate-width) - (2 * #{toolbarbutton-padding.inner()})) !important;
 
   margin-inline: auto !important; /* Original: var(--urlbar-margin-inline) */
   left: 50%;

--- a/src/others/_findbar_floating_on_top.scss
+++ b/src/others/_findbar_floating_on_top.scss
@@ -48,7 +48,7 @@ findbar {
   border-radius: var(--uc-rounding-toolbar, var(--toolbarbutton-border-radius)) 0 0 var(--uc-rounding-toolbar, var(--toolbarbutton-border-radius)) !important;
 
   > .findbar-find-fast {
-    padding: var(--toolbarbutton-inner-padding) 1px;
+    padding: #{toolbarbutton-padding.inner()} 1px;
     margin: 0 !important;
   }
   > .findbar-find-status {

--- a/src/padding/_tabbar_height.scss
+++ b/src/padding/_tabbar_height.scss
@@ -58,7 +58,7 @@
   }
 
   #TabsToolbar {
-    --toolbarbutton-inner-padding: calc((var(--tab-min-height) - 18px) / 2) !important; /* Prevent overflow pinned tab bottom margin */
+    @include toolbarbutton-padding.inner(calc((var(--tab-min-height) - 18px) / 2) !important); /* Prevent overflow pinned tab bottom margin */
   }
 
   @include NotOption("userChrome.tabbar.multi_row") {
@@ -88,10 +88,10 @@
 }
 #scrollbutton-up,
 #scrollbutton-down {
-  /* Original: var(--toolbarbutton-inner-padding) calc(var(--toolbarbutton-inner-padding) - 6px) = 9px */
+  /* Original: #{toolbarbutton-padding.inner()} calc(#{toolbarbutton-padding.inner()} - 6px) = 9px */
   /* https://github.com/mozilla/gecko-dev/blob/71b1259afd1cdaf41871ae675c2dadb967ea5b34/browser/themes/shared/toolbarbuttons.inc.css#L142 */
-  padding-top: var(--scrollbtn-vertical-padding, var(--toolbarbutton-inner-padding)) !important;
-  padding-bottom: var(--scrollbtn-vertical-padding, var(--toolbarbutton-inner-padding)) !important;
+  padding-top: var(--scrollbtn-vertical-padding, #{toolbarbutton-padding.inner()}) !important;
+  padding-bottom: var(--scrollbtn-vertical-padding, #{toolbarbutton-padding.inner()}) !important;
 
   /* Original: 4px */
   border-top-width: var(--scrollbtn-vertical-border, 4px) !important;

--- a/src/padding/_tabbar_width.scss
+++ b/src/padding/_tabbar_width.scss
@@ -27,7 +27,7 @@
 /* Tabbar Buttons */
 :root {
   --newtab-button-minus-width-padding: 2px;
-  --newtab-button-width-padding: calc(var(--toolbarbutton-inner-padding) - var(--newtab-button-minus-width-padding));
+  --newtab-button-width-padding: calc(#{toolbarbutton-padding.inner()} - var(--newtab-button-minus-width-padding));
 }
 #widget-overflow-mainView {
   #new-tab-button,
@@ -37,7 +37,7 @@
 }
 #new-tab-button > .toolbarbutton-icon,
 #alltabs-button > .toolbarbutton-badge-stack {
-  /* Original: calc(2 * var(--toolbarbutton-inner-padding) + 16px) */
+  /* Original: calc(2 * #{toolbarbutton-padding.inner()} + 16px) */
   width: calc(2 * var(--newtab-button-width-padding) + 16px) !important;
 
   /* Original: --toolbarbutton-inner-padding */
@@ -76,7 +76,7 @@
 
 :root:not([uidensity="touch"]) #new-tab-button,
 #alltabs-button {
-  --toolbarbutton-outer-padding: 1px; /* Original: 2px*/
+  @include toolbarbutton-padding.outer(1px); /* Original: 2px*/
 }
 
 /* Tab - Max Size */

--- a/src/padding/_toolbar_button.scss
+++ b/src/padding/_toolbar_button.scss
@@ -1,9 +1,9 @@
 :root[uidensity="compact"] {
-  --toolbarbutton-outer-padding: 2px !important; /* Original: 3px, General is 2px */
+  @include toolbarbutton-padding.outer(2px !important); /* Original: 3px, General is 2px */
 }
 
 @include Option("userChrome.padding.toolbar_button.compact") {
   :root {
-    --toolbarbutton-inner-padding: var(--uc-small-toolbarbutton-inner-padding) !important;
+    @include toolbarbutton-padding.inner(var(--uc-small-toolbarbutton-inner-padding) !important);
   }
 }

--- a/src/tab/newtab_button/_looks_like_tab.scss
+++ b/src/tab/newtab_button/_looks_like_tab.scss
@@ -58,7 +58,7 @@
         "userChrome.tab.bottom_rounded_corner.chrome",
         "userChrome.tab.bottom_rounded_corner.edge"
       ) {
-        --uc-newtab-non-corner-bgwidth: calc(2 * var(--toolbarbutton-inner-padding));
+        --uc-newtab-non-corner-bgwidth: calc(2 * #{toolbarbutton-padding.inner()});
       }
     }
   }
@@ -119,8 +119,8 @@
 #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button .toolbarbutton-icon {
   border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0 !important; /* Original: var(--tab-border-radius) */
 
-  padding: calc(var(--toolbarbutton-inner-padding) - (var(--tab-block-margin) / 4)) var(--toolbarbutton-inner-padding)
-    calc(var(--toolbarbutton-inner-padding) + (var(--tab-block-margin) / 4) + var(--uc-tabs-navbar-shadow-size)) !important;
+  padding: calc(#{toolbarbutton-padding.inner()} - (var(--tab-block-margin) / 4)) #{toolbarbutton-padding.inner()}
+    calc(#{toolbarbutton-padding.inner()} + (var(--tab-block-margin) / 4) + var(--uc-tabs-navbar-shadow-size)) !important;
   -moz-context-properties: fill, fill-opacity;
   fill: var(--toolbarbutton-icon-fill);
   fill-opacity: var(--toolbarbutton-icon-fill-opacity);
@@ -138,7 +138,7 @@
     margin-inline: calc(var(--uc-tab-corner-half-height) - #{math.div(15.5px, 2)}) !important;
 
     background-color: transparent !important;
-    // background-size: calc((var(--toolbarbutton-inner-padding) * 2 + 16px) - var(--uc-tab-corner-size)) 100%;
+    // background-size: calc((#{toolbarbutton-padding.inner()} * 2 + 16px) - var(--uc-tab-corner-size)) 100%;
     // background-repeat: no-repeat;
     // background-position: center;
   }

--- a/src/tab/newtab_button/_proton_like_button.scss
+++ b/src/tab/newtab_button/_proton_like_button.scss
@@ -1,3 +1,3 @@
 :root:not([uidensity="touch"]) #tabs-newtab-button > .toolbarbutton-icon {
-  --toolbarbutton-inner-padding: calc((var(--tab-min-height) - 16px) / 2 - 1px);
+  @include toolbarbutton-padding.inner(calc((var(--tab-min-height) - 16px) / 2 - 1px));
 }

--- a/src/tab/newtab_button/_smaller_button.scss
+++ b/src/tab/newtab_button/_smaller_button.scss
@@ -4,5 +4,5 @@
   margin-left: 1px;
 
   /* Original: calc((var(--tab-min-height) - 16px) / 2) = 10px */
-  --toolbarbutton-inner-padding: var(--uc-small-toolbarbutton-inner-padding);
+  @include toolbarbutton-padding.inner(var(--uc-small-toolbarbutton-inner-padding));
 }

--- a/src/tab/unselected_tab/_dynamic_separator.scss
+++ b/src/tab/unselected_tab/_dynamic_separator.scss
@@ -49,7 +49,7 @@
     transform: translateX(var(--tab-separator-position-x)) translateY(var(--tab-separator-position-y));
   }
   #tabbrowser-tabs:not([orient="vertical"]) #tabs-newtab-button::before {
-    left: calc(50%  - (8px + var(--toolbarbutton-inner-padding)));
+    left: calc(50%  - (8px + #{toolbarbutton-padding.inner()}));
   }
 }
 

--- a/src/tabbar/_on_bottom.scss
+++ b/src/tabbar/_on_bottom.scss
@@ -101,7 +101,7 @@ See the above repository for updates as well as full license text. */
   }
 
   #toolbar-menubar .toolbarbutton-1 {
-    --toolbarbutton-inner-padding: 3px;
+    @include toolbarbutton-padding.inner(3px);
   }
 
   :root:not([chromehidden~="menubar"], [sizemode="fullscreen"]) #toolbar-menubar:not([autohide="true"]) + #TabsToolbar > .titlebar-buttonbox-container{

--- a/src/tabbar/_one_liner.scss
+++ b/src/tabbar/_one_liner.scss
@@ -47,7 +47,7 @@
   }
 
   #nav-bar {
-    --toolbarbutton-inner-padding: 6px; /* Original: 8px */
+    @include toolbarbutton-padding.inner(6px); /* Original: 8px */
     border-radius: var(--uc-rounding-toolbar, var(--tab-border-radius, 4px));
   }
 
@@ -77,10 +77,10 @@
 #urlbar-container {
   // https://github.com/mozilla/gecko-dev/commit/f30aeeee449c753d7494c788cae58dae7e1a92e5
   // https://github.com/mozilla/gecko-dev/commit/42a66e80d97bc07b25be913c02fd004ee9c7ca1a
-  min-width: calc(var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * var(--toolbarbutton-inner-padding)) !important; // Original: calc(350px + 24px + 2 * var(--toolbarbutton-inner-padding))
+  min-width: calc(var(--uc-oneliner-urlbar-base-width, 50px) + 24px + 2 * #{toolbarbutton-padding.inner()}) !important; // Original: calc(350px + 24px + 2 * #{toolbarbutton-padding.inner()})
 }
 #urlbar[breakout][breakout-extend] {
-  min-width: calc(310px + 2 * (24px + 2 * var(--toolbarbutton-inner-padding))) !important;
+  min-width: calc(310px + 2 * (24px + 2 * #{toolbarbutton-padding.inner()})) !important;
 }
 
 #PersonalToolbar {

--- a/src/tabbar/_unscroll.scss
+++ b/src/tabbar/_unscroll.scss
@@ -48,7 +48,7 @@ spacer[part="overflow-start-indicator"] + .scrollbox-clip > scrollbox {
 
     #pinned-tabs-container,
     #tabbrowser-arrowscrollbox {
-      padding-inline-end: calc(16px + (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding)) * 2) !important;
+      padding-inline-end: calc(16px + (#{toolbarbutton-padding.inner()} + #{toolbarbutton-padding.outer()}) * 2) !important;
     }
   }
 }

--- a/src/urlview/_as_launcher.scss
+++ b/src/urlview/_as_launcher.scss
@@ -46,13 +46,13 @@ $_urlRowPadding: 2px; //.urlbarView-row
   @include _urlViewCompactInit;
   @include _urlViewTouchInit;
 
-  --uc-urlView-margin: calc(var(--uc-sidebar-activate-width, 18rem) + var(--toolbarbutton-inner-padding));
+  --uc-urlView-margin: calc(var(--uc-sidebar-activate-width, 18rem) + #{toolbarbutton-padding.inner()});
 
   position: fixed !important;
   left: 50vw;
   transform: translateX(-50%);
   top: 12vh !important;
-  width: calc(100vw - (var(--uc-urlView-margin) + var(--toolbarbutton-inner-padding))) !important;
+  width: calc(100vw - (var(--uc-urlView-margin) + #{toolbarbutton-padding.inner()})) !important;
 
   /* paddding as margin */
   @include NotOption("userChrome.urlView.full_width_padding") {

--- a/src/utils/toolbarbutton-padding.scss
+++ b/src/utils/toolbarbutton-padding.scss
@@ -1,0 +1,33 @@
+@use "mode";
+
+@function outer() {
+    @if mode.isESR() {
+        @return var(--toolbarbutton-outer-padding);
+    } @else {
+        @return var(--toolbarbutton-padding-outer);
+    }
+}
+
+@function inner() {
+    @if mode.isESR() {
+        @return var(--toolbarbutton-inner-padding);
+    } @else {
+        @return var(--toolbarbutton-padding-inner);
+    }
+}
+
+@mixin outer($value) {
+    @if mode.isESR() {
+        --toolbarbutton-outer-padding: #{$value};
+    } @else {
+        --toolbarbutton-padding-outer: #{$value};
+    }
+}
+
+@mixin inner($value) {
+    @if mode.isESR() {
+        --toolbarbutton-inner-padding: #{$value};
+    } @else {
+        --toolbarbutton-padding-inner: #{$value};
+    }
+}


### PR DESCRIPTION
**Describe the PR**
<!-- A clear and concise description of what the PR is. -->

In Firefox 152 they changed the names of the toolbarbutton padding variables from `--toolbarbutton-inner-padding` to `--toolbarbutton-padding-inner` and `--toolbarbutton-outer-padding` to `--toolbarbutton-padding-outer`. This PR adds utilties to automatically switch between both variables based on mode supporting both latest & esr version.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
<!--Related or discussed issues. If it's a big change, it's a good idea to open an issue ahead of time. -->

Fixes #1178, but probably more

**Screenshots**
<!-- If applicable, add screenshots to help explain your commit. -->

**Additional context**
<!-- Add any other context about the commit here. -->