### PR TITLE
fix: Auto-hide navbar/toolbar no longer reclaims page space (#1180)

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -10547,7 +10547,14 @@
 @media -moz-pref("userChrome.autohide.back_button") or -moz-pref("userChrome.autohide.forward_button") {
   :root {
     --uc-toolbarbutton-hide-size: calc(
-      -1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding))))
+      -1 * (16px +
+            (
+              2 *
+                (
+                  var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding)) +
+                    var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding))
+                )
+            ))
     );
   }
 }
@@ -10673,7 +10680,11 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
     --uc-navbar-height: var(--uc-navbar-height-default);
     --uc-navbar-height-default: calc(
-      16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding))
+      16px + 2 *
+        (
+          var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding)) +
+            var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding))
+        )
     );
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
     --uc-bm-height: var(--uc-bm-height-default);
@@ -26201,7 +26212,14 @@
 @media (-moz-bool-pref: "userChrome.autohide.back_button"), (-moz-bool-pref: "userChrome.autohide.forward_button") {
   :root {
     --uc-toolbarbutton-hide-size: calc(
-      -1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding))))
+      -1 * (16px +
+            (
+              2 *
+                (
+                  var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding)) +
+                    var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding))
+                )
+            ))
     );
   }
 }
@@ -26329,7 +26347,11 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
     --uc-navbar-height: var(--uc-navbar-height-default);
     --uc-navbar-height-default: calc(
-      16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding))
+      16px + 2 *
+        (
+          var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding)) +
+            var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding))
+        )
     );
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
     --uc-bm-height: var(--uc-bm-height-default);

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -11015,7 +11015,14 @@
 @supports -moz-bool-pref("userChrome.autohide.back_button") or -moz-bool-pref("userChrome.autohide.forward_button") {
   :root {
     --uc-toolbarbutton-hide-size: calc(
-      -1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding))))
+      -1 * (16px +
+            (
+              2 *
+                (
+                  var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding)) +
+                    var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding))
+                )
+            ))
     );
   }
 }
@@ -11146,7 +11153,11 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
     --uc-navbar-height: var(--uc-navbar-height-default);
     --uc-navbar-height-default: calc(
-      16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding))
+      16px + 2 *
+        (
+          var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding)) +
+            var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding))
+        )
     );
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
     --uc-bm-height: var(--uc-bm-height-default);

--- a/src/autohide/_common.scss
+++ b/src/autohide/_common.scss
@@ -18,7 +18,9 @@
     --uc-tabbar-hide-height: calc(-1 * var(--uc-tabbar-height));
 
     --uc-navbar-height: var(--uc-navbar-height-default);
-    --uc-navbar-height-default: calc(16px + 2 * (var(--toolbarbutton-inner-padding) + var(--toolbarbutton-outer-padding)));
+    // Firefox 153+ renamed --toolbarbutton-inner-padding/-outer-padding to
+    // --toolbarbutton-padding-inner/-outer; fall back to the old names for older/ESR builds.
+    --uc-navbar-height-default: calc(16px + 2 * (var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding)) + var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding))));
     --uc-navbar-hide-height: calc(-1 * var(--uc-navbar-height));
 
     --uc-bm-height: var(--uc-bm-height-default);

--- a/src/autohide/_index.scss
+++ b/src/autohide/_index.scss
@@ -1,6 +1,8 @@
 @include Option("userChrome.autohide.back_button", "userChrome.autohide.forward_button") {
   :root {
-    --uc-toolbarbutton-hide-size: calc(-1 * (16px + (2 * (var(--toolbarbutton-outer-padding) + var(--toolbarbutton-inner-padding)))));
+    // Firefox 153+ renamed --toolbarbutton-inner-padding/-outer-padding to
+    // --toolbarbutton-padding-inner/-outer; fall back to the old names for older/ESR builds.
+    --uc-toolbarbutton-hide-size: calc(-1 * (16px + (2 * (var(--toolbarbutton-padding-outer, var(--toolbarbutton-outer-padding)) + var(--toolbarbutton-padding-inner, var(--toolbarbutton-inner-padding))))));
   }
 }
 


### PR DESCRIPTION
**Describe the PR**

Firefox 153 renamed the `--toolbarbutton-inner-padding`/`-outer-padding` CSS variables to `--toolbarbutton-padding-inner`/`-outer`. The autohide navbar-height and back/forward-button hide-size `calc()`s at `:root` still referenced the old names exclusively, so on current Firefox the `var()` reference is invalid, invalidating the whole `calc()` chain and leaving `margin-bottom` at its initial 0 instead of the intended negative value. The toolbar still visually fades (`opacity: 0`, a separate declaration) but the reclaimed space never shrinks, matching the symptom in #1180.

Reference the new variable names first, falling back to the old ones so this keeps working on ESR/older Firefox builds that still use them.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**

https://github.com/black7375/Firefox-UI-Fix/issues/1180

**Screenshots**

<img width="1227" height="81" alt="image" src="https://github.com/user-attachments/assets/10dd06e7-0c67-4567-9f15-6aed2e5893cf" />