### PR TITLE
Fix: Install - PowerShell variable scope mismatch in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -386,7 +386,7 @@ function Menu {
 #** Profile ********************************************************************
 #== Profile Dir ================================================================
 # $HOME = (get-psprovider 'FileSystem').Home
-$firefoxProfileDirPaths = @(
+$global:firefoxProfileDirPaths = @(
   "${HOME}\AppData\Roaming\Mozilla\Firefox",
   "${HOME}\AppData\Roaming\Waterfox",
   "${HOME}\AppData\Roaming\librewolf",
@@ -427,7 +427,7 @@ function Check-ProfileIni() {
 }
 
 #== Profile PATH ===============================================================
-$firefoxProfilePaths = @()
+$global:firefoxProfilePaths = @()
 function Update-ProfilePaths() {
   foreach ( $profileDir in $global:firefoxProfileDirPaths ) {
     $local:iniContent = Get-IniContent "${profileDir}\${PROFILEINFOFILE}"
@@ -578,8 +578,8 @@ function Write-LeptonInfo() {
 
 #** Install ********************************************************************
 #== Install Types ==============================================================
-$updateMode   = $false
-$leptonBranch = "master"
+$global:updateMode   = $false
+$global:leptonBranch = "master"
 function Select-Distribution() {
   while ( $true ) {
     $local:selected = $false
@@ -599,7 +599,7 @@ function Select-Distribution() {
   Lepton-OkMessage "Selected ${selectedDistribution}"
 }
 
-$leptonInstallType = "Network" # Other types: Local, Release
+$global:leptonInstallType = "Network" # Other types: Local, Release
 function Check-InstallType() {
   Param (
     [Parameter(Mandatory=$true, Position=0)]
@@ -644,14 +644,14 @@ function Check-InstallTypes() {
 }
 
 #== Custom Install =============================================================
-$customFiles = @(
+$global:customFiles = @(
   "user-overrides.js",
   "userChrome-overrides.css",
   "userContent-overrides.css"
 )
-$localCustomFiles = $customFiles.Clone()
+$global:localCustomFiles = $customFiles.Clone()
 
-$customFileExist = $false
+$global:customFileExist = $false
 function Check-CustomFiles() {
   [System.Collections.Generic.List[string]]$global:localCustomFiles = Filter-Path $localCustomFiles
 
@@ -685,9 +685,9 @@ function Copy-CustomFiles() {
   }
 }
 
-$customMethod = ""
-$customReset  = $false
-$customAppend = $false
+$global:customMethod = ""
+$global:customReset  = $false
+$global:customAppend = $false
 function Set-CustomMethod() {
   $local:menuAppend="Append - Maintain changes in existing files and apply custom"
   $local:menuOverwrite="Overwrite - After initializing the change, apply only custom"
@@ -721,7 +721,7 @@ function Set-CustomMethod() {
   Lepton-OKMessage "Selected ${customMethod}"
 }
 
-$customFileApplied = $false
+$global:customFileApplied = $false
 function Apply-CustomFile() {
   Param (
     [Parameter(Mandatory=$true, Position=0)]
@@ -785,7 +785,7 @@ function Apply-CustomFiles() {
 }
 
 #== Install Helpers ============================================================
-$chromeDuplicate = $false
+$global:chromeDuplicate = $false
 function Check-ChromeExist() {
   if ( (Test-Path -Path "chrome") -and (-Not (Test-Path -Path "chrome\${LEPTONINFOFILE}")) ) {
     $global:chromeDuplicate = $true
@@ -936,7 +936,7 @@ function Update-Profile() {
           Check-ChromeExist
           Clone-Lepton
 
-          $firefoxProfilePaths = @("${Path}")
+          $global:firefoxProfilePaths = @("${Path}")
           Copy-Lepton
 
           if ( "${Branch}" -eq $null ) {


### PR DESCRIPTION
## Problem

`install.ps1` fails with `FAILED: Doesn't exist profiles` even when `profiles.ini` exists and is valid.

## Repro

Must be run **from an already-open PowerShell session** — this is the key detail. A script launched as the process entry point (`powershell -File install.ps1`, "Run with PowerShell" from Explorer, or the documented `iex` one-liner) gets a script scope that *is* the global scope, so the bug is invisible there.

```powershell
PS C:\> .\install.ps1
```

Output (matches the screenshots in #546 exactly):

```
Filter-Path : Cannot bind argument to parameter 'pathList' because it is null.
At ...\install.ps1:408 char:48
Profiles dir found ...............................OK
Profiles info file found .........................OK
Lepton-ErrorMessage : FAILED: Doesn't exist profiles
At ...\install.ps1:441 char:5
```

## Cause

13 top-level variables are declared in *script* scope but assigned via `$global:` inside functions. Writes and reads therefore target two different variables. In a child scope the chain collapses:

| Line | What happens |
|---|---|
| 389 | `$firefoxProfileDirPaths = @(...)` lands in script scope |
| 408 | `Filter-Path $global:firefoxProfileDirPaths` — global is still `$null` |
| 410 | unqualified read sees the script-scope copy → **false** `Profiles dir found` OK |
| 420 | `foreach` over `$null` → 0 iterations → **false** `Profiles info file found` OK |
| 434 | same `foreach` over `$null` → nothing accumulated |
| 437 | unqualified read sees the empty script-scope array → `Doesn't exist profiles` |

The two green OK messages are false positives, which is why the error is so confusing to diagnose — see the reporter's comment in #546.

The same mismatch silently broke the distribution menu: selecting Photon-Style set `$global:leptonBranch`, but `Clone-Lepton` (line 817) reads `$leptonBranch` unqualified and still cloned `master`.

Affected variables:

```
firefoxProfileDirPaths  firefoxProfilePaths  updateMode    leptonBranch
leptonInstallType       customFiles          localCustomFiles
customFileExist         customMethod         customReset   customAppend
customFileApplied       chromeDuplicate
```

## Fix

Declare the 13 affected variables with `$global:` so the declaration and every access refer to one variable. No behaviour change under the documented `iex` install path, where script scope already *is* global.

## Verification

|  | before | after |
|---|---|---|
| `Filter-Path` (line 408) | `Cannot bind argument… is null` | clean |
| profile detection | `FAILED: Doesn't exist profiles` | 2 profiles found, exit 0 |
| menu picks Photon-Style | installs **master** | installs `photon-style` |
| `PSParser` syntax check | — | no errors |

Fixes #546
