### PR TITLE
Fix window controls when horizontal tab bar is hidden

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -5568,11 +5568,14 @@
       }
     }
   }
-  @supports selector(:has(a)) {
-    #navigator-toolbox:has(#toolbar-menubar[autohide="false"]) {
-      --uc-window-drag-space-pre: 0px;
+  @media -moz-pref("userChrome.hidden.tabbar") {
+    #navigator-toolbox {
       --uc-window-control-space: 0px;
     }
+  }
+  #navigator-toolbox:has(#toolbar-menubar:not([autohide], [collapsed])) {
+    --uc-window-drag-space-pre: 0px;
+    --uc-window-control-space: 0px;
   }
 }
 @media -moz-pref("userChrome.tabbar.on_bottom") or -moz-pref("userChrome.tabbar.one_liner") or -moz-pref("userChrome.hidden.tabbar") {
@@ -6854,6 +6857,34 @@
           right: unset;
         }
       }
+    }
+  }
+}
+@media -moz-pref("userChrome.hidden.tabbar") {
+  @media not -moz-pref("userChrome.hidden.titlebar_container") {
+    #nav-bar > .titlebar-buttonbox-container {
+      display: flex !important;
+    }
+    @media (-moz-platform: windows) {
+      :root[sizemode="normal"] #toolbar-menubar[autohide][inactive] ~ #nav-bar > .titlebar-spacer[type="post-tabs"] {
+        display: flex !important;
+        width: var(--uc-window-drag-space-pre) !important;
+      }
+    }
+    @media (-moz-gtk-csd-available) and (-moz-gtk-csd-reversed-placement: 0) {
+      :root[sizemode="normal"] #toolbar-menubar[autohide][inactive] ~ #nav-bar > .titlebar-spacer[type="post-tabs"] {
+        display: flex !important;
+        width: var(--uc-window-drag-space-pre) !important;
+      }
+    }
+    #toolbar-menubar[inactive] > .titlebar-buttonbox-container {
+      display: none !important;
+    }
+    :root:not([chromehidden~="menubar"], [inFullscreen])
+      #toolbar-menubar:not([autohide], [collapsed])
+      ~ #nav-bar
+      > .titlebar-buttonbox-container {
+      display: none !important;
     }
   }
 }
@@ -20583,15 +20614,21 @@
     --uc-window-control-space: 0px;
   }
 }
+@media (-moz-bool-pref: "userChrome.tabbar.on_bottom") and (-moz-bool-pref: "userChrome.hidden.tabbar"),
+  (-moz-bool-pref: "userChrome.tabbar.one_liner") and (-moz-bool-pref: "userChrome.hidden.tabbar"),
+  (-moz-bool-pref: "userChrome.hidden.tabbar") and (-moz-bool-pref: "userChrome.hidden.tabbar"),
+  (-moz-bool-pref: "userChrome.tabbar.as_titlebar") and (-moz-bool-pref: "userChrome.hidden.tabbar") {
+  #navigator-toolbox {
+    --uc-window-control-space: 0px;
+  }
+}
 @media (-moz-bool-pref: "userChrome.tabbar.on_bottom"),
   (-moz-bool-pref: "userChrome.tabbar.one_liner"),
   (-moz-bool-pref: "userChrome.hidden.tabbar"),
   (-moz-bool-pref: "userChrome.tabbar.as_titlebar") {
-  @supports selector(:has(a)) {
-    #navigator-toolbox:has(#toolbar-menubar[autohide="false"]) {
-      --uc-window-drag-space-pre: 0px;
-      --uc-window-control-space: 0px;
-    }
+  #navigator-toolbox:has(#toolbar-menubar:not([autohide], [collapsed])) {
+    --uc-window-drag-space-pre: 0px;
+    --uc-window-control-space: 0px;
   }
 }
 @media (-moz-bool-pref: "userChrome.tabbar.on_bottom") and (not (-moz-bool-pref: "userChrome.hidden.titlebar_container")) and (not (-moz-bool-pref: "userChrome.tabbar.one_liner")) and (-moz-bool-pref: "userChrome.tabbar.on_bottom"),
@@ -22206,6 +22243,36 @@
   :root[sizemode="fullscreen"] #TabsToolbar > .titlebar-buttonbox-container:last-child,
   :root[sizemode="fullscreen"] #window-controls {
     right: unset;
+  }
+}
+@media (-moz-bool-pref: "userChrome.hidden.tabbar") and (not (-moz-bool-pref: "userChrome.hidden.titlebar_container")) {
+  #nav-bar > .titlebar-buttonbox-container {
+    display: flex !important;
+  }
+}
+@media (-moz-bool-pref: "userChrome.hidden.tabbar") and (not (-moz-bool-pref: "userChrome.hidden.titlebar_container")) and (-moz-platform: windows) {
+  :root[sizemode="normal"] #toolbar-menubar[autohide][inactive] ~ #nav-bar > .titlebar-spacer[type="post-tabs"] {
+    display: flex !important;
+    width: var(--uc-window-drag-space-pre) !important;
+  }
+}
+@media (-moz-bool-pref: "userChrome.hidden.tabbar") and (not (-moz-bool-pref: "userChrome.hidden.titlebar_container")) and (-moz-gtk-csd-available) and (-moz-gtk-csd-reversed-placement: 0) {
+  :root[sizemode="normal"] #toolbar-menubar[autohide][inactive] ~ #nav-bar > .titlebar-spacer[type="post-tabs"] {
+    display: flex !important;
+    width: var(--uc-window-drag-space-pre) !important;
+  }
+}
+@media (-moz-bool-pref: "userChrome.hidden.tabbar") and (not (-moz-bool-pref: "userChrome.hidden.titlebar_container")) {
+  #toolbar-menubar[inactive] > .titlebar-buttonbox-container {
+    display: none !important;
+  }
+}
+@media (-moz-bool-pref: "userChrome.hidden.tabbar") and (not (-moz-bool-pref: "userChrome.hidden.titlebar_container")) {
+  :root:not([chromehidden~="menubar"], [inFullscreen])
+    #toolbar-menubar:not([autohide], [collapsed])
+    ~ #nav-bar
+    > .titlebar-buttonbox-container {
+    display: none !important;
   }
 }
 /*= Tab Bar - Show only current tab ==========================================*/

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -5956,11 +5956,14 @@
       }
     }
   }
-  @supports selector(:has(a)) {
-    #navigator-toolbox:has(#toolbar-menubar[autohide="false"]) {
-      --uc-window-drag-space-pre: 0px;
+  @supports -moz-bool-pref("userChrome.hidden.tabbar") {
+    #navigator-toolbox {
       --uc-window-control-space: 0px;
     }
+  }
+  #navigator-toolbox:has(#toolbar-menubar:not([autohide], [collapsed])) {
+    --uc-window-drag-space-pre: 0px;
+    --uc-window-control-space: 0px;
   }
 }
 @supports -moz-bool-pref("userChrome.tabbar.on_bottom") or -moz-bool-pref("userChrome.tabbar.one_liner") or -moz-bool-pref(
@@ -7292,6 +7295,37 @@
           right: unset;
         }
       }
+    }
+  }
+}
+@supports -moz-bool-pref("userChrome.hidden.tabbar") {
+  @supports not -moz-bool-pref("userChrome.hidden.titlebar_container") {
+    #nav-bar > .titlebar-buttonbox-container {
+      display: flex !important;
+    }
+    @media (-moz-os-version: windows-win7),
+      (-moz-os-version: windows-win8),
+      (-moz-os-version: windows-win10),
+      (-moz-platform: windows) {
+      :root[sizemode="normal"] #toolbar-menubar[autohide][inactive] ~ #nav-bar > .titlebar-spacer[type="post-tabs"] {
+        display: flex !important;
+        width: var(--uc-window-drag-space-pre) !important;
+      }
+    }
+    @media (-moz-gtk-csd-available) and (-moz-gtk-csd-reversed-placement: 0) {
+      :root[sizemode="normal"] #toolbar-menubar[autohide][inactive] ~ #nav-bar > .titlebar-spacer[type="post-tabs"] {
+        display: flex !important;
+        width: var(--uc-window-drag-space-pre) !important;
+      }
+    }
+    #toolbar-menubar[inactive] > .titlebar-buttonbox-container {
+      display: none !important;
+    }
+    :root:not([chromehidden~="menubar"], [inFullscreen])
+      #toolbar-menubar:not([autohide], [collapsed])
+      ~ #nav-bar
+      > .titlebar-buttonbox-container {
+      display: none !important;
     }
   }
 }

--- a/src/tabbar/_index.scss
+++ b/src/tabbar/_index.scss
@@ -39,6 +39,11 @@
 @include Option("userChrome.tabbar.on_bottom", "userChrome.tabbar.one_liner", "userChrome.hidden.tabbar") {
   @import "layout";
 }
+@include Option("userChrome.hidden.tabbar") {
+  @include NotOption("userChrome.hidden.titlebar_container") {
+    @import "layout/hidden_tabbar_window_control";
+  }
+}
 
 /*= Tab Bar - Show only current tab ==========================================*/
 @include Option("userChrome.tabbar.as_titlebar") {

--- a/src/tabbar/layout/_hidden_tabbar_window_control.scss
+++ b/src/tabbar/layout/_hidden_tabbar_window_control.scss
@@ -1,0 +1,34 @@
+// Firefox keeps a titlebar-control copy in the nav bar and normally enables it
+// only when native vertical tabs set `tabs-hidden`. Lepton hides the horizontal
+// tab bar with CSS, so opt into that copy directly.
+#nav-bar > .titlebar-buttonbox-container {
+  display: flex !important;
+}
+
+// Match the drag space at the start of the nav bar on the inner side of
+// right-aligned window controls. Firefox normally exposes this spacer only
+// when its native tab strip is hidden.
+@include WindowControl_Right {
+  :root[sizemode="normal"]
+    #toolbar-menubar[autohide][inactive]
+    ~ #nav-bar
+    > .titlebar-spacer[type="post-tabs"] {
+    display: flex !important;
+    width: var(--uc-window-drag-space-pre) !important;
+  }
+}
+
+// Lepton's existing hidden-tabbar rules expose the menubar copy, so suppress it
+// while the nav-bar copy is in use.
+#toolbar-menubar[inactive] > .titlebar-buttonbox-container {
+  display: none !important;
+}
+
+// A permanently visible menubar owns the controls, so hide the nav-bar copy
+// just as Firefox does for native vertical tabs.
+:root:not([chromehidden~="menubar"], [inFullscreen])
+  #toolbar-menubar:not([autohide], [collapsed])
+  ~ #nav-bar
+  > .titlebar-buttonbox-container {
+  display: none !important;
+}

--- a/src/tabbar/layout/_window_control_size.scss
+++ b/src/tabbar/layout/_window_control_size.scss
@@ -102,9 +102,16 @@
   }
 }
 
-@include Has {
-  #navigator-toolbox:has(#toolbar-menubar[autohide="false"]) {
-    @include _remove_spacer_pre;
+@include Option("userChrome.hidden.tabbar") {
+  // The nav bar contains the actual controls, so don't reserve an additional
+  // fixed-width gap. Retain the pre-control drag space in a normal window.
+  #navigator-toolbox {
     @include _remove_spacer_post;
   }
+}
+
+// A permanently visible menu bar has no `autohide` attribute.
+#navigator-toolbox:has(#toolbar-menubar:not([autohide], [collapsed])) {
+  @include _remove_spacer_pre;
+  @include _remove_spacer_post;
 }


### PR DESCRIPTION
**Describe the PR**

Firefox now provides window controls and drag spacers in the navigation toolbar for configurations where the horizontal tab strip is hidden. Lepton previously continued using the menubar/tabbar control layout and reserving a fixed window-control gap, which caused:

- Empty space in the navigation toolbar
- Missing controls when the menubar was hidden

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
#1145

