### PR TITLE
Changed many [selected=true] to [selected]

### DIFF
--- a/css/leptonChrome.css
+++ b/css/leptonChrome.css
@@ -2189,7 +2189,7 @@
     background-color: var(--button-hover-bgcolor, color-mix(in srgb, currentColor 17%, transparent)) !important;
   }
   :root:is(:-moz-lwtheme, [lwtheme]) #editBMPanel_folderTree > treechildren::-moz-tree-row(selected),
-  #editBMPanel_tagsSelector > richlistitem[selected="true"] {
+  #editBMPanel_tagsSelector > richlistitem[selected] {
     background-color: var(--button-active-bgcolor, color-mix(in srgb, currentColor 30%, transparent)) !important;
   }
   #editBookmarkPanel #editBMPanel_namePicker,
@@ -2932,8 +2932,8 @@
       color: var(--in-content-item-hover-text) !important;
       background-color: var(--in-content-item-hover) !important;
     }
-    xul|menulist > xul|menupopup > xul|menu:not([disabled="true"])[selected="true"],
-    xul|menulist > xul|menupopup > xul|menuitem:not([disabled="true"])[selected="true"] {
+    xul|menulist > xul|menupopup > xul|menu:not([disabled="true"])[selected],
+    xul|menulist > xul|menupopup > xul|menuitem:not([disabled="true"])[selected] {
       color: var(--in-content-item-selected-text) !important;
       background-color: var(--in-content-item-selected) !important;
     }
@@ -3072,7 +3072,7 @@
     }
     @media -moz-pref("layout.css.osx-font-smoothing.enabled") {
       xul|menulist > xul|menupopup > xul|menuitem[checked="true"]::before,
-      xul|menulist > xul|menupopup > xul|menuitem[selected="true"]::before {
+      xul|menulist > xul|menupopup > xul|menuitem[selected]::before {
         display: none !important;
       }
       xul|menulist::part(dropmarker) {
@@ -3169,7 +3169,7 @@
     #viewGroup > radio:hover {
       background-color: var(--in-content-button-background-hover) !important; /* #E0E8F6; */
     }
-    #viewGroup > radio[selected="true"] {
+    #viewGroup > radio[selected] {
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }
@@ -3455,12 +3455,12 @@
       #clearDownloadsButton:focus-visible {
         outline: 2px solid var(--organizer-outline-color) !important;
       }
-      richlistitem[selected="true"],
+      richlistitem[selected],
       richlistitem:hover {
         background-color: var(--organizer-hover-background) !important;
         color: var(--organizer-color) !important;
       }
-      richlistbox:where(:focus) > richlistitem[selected="true"] {
+      richlistbox:where(:focus) > richlistitem[selected] {
         background-color: var(--organizer-selected-background) !important;
       }
       /*- Tree -----------------------------------------------------------------*/
@@ -6844,26 +6844,26 @@
   #scrollbutton-down,
   .titlebar-spacer[type="pre-tabs"],
   spacer:is([part="overflow-start-indicator"], [part="overflow-end-indicator"]),
-  .tabbrowser-tab:not([selected="true"]),
-  .tabbrowser-tab[selected="true"] .tab-background,
-  .tabbrowser-tab[selected="true"] .tab-stack:is(::before, ::after),
-  .tabbrowser-tab[selected="true"] .tab-close-button,
+  .tabbrowser-tab:not([selected]),
+  .tabbrowser-tab[selected] .tab-background,
+  .tabbrowser-tab[selected] .tab-stack:is(::before, ::after),
+  .tabbrowser-tab[selected] .tab-close-button,
   #tabs-newtab-button {
     display: none !important;
   }
-  .tabbrowser-tab[selected="true"] {
+  .tabbrowser-tab[selected] {
     -moz-window-dragging: drag;
     --tab-max-width: 100vw;
     min-width: calc(var(--uc-tabbar-width, 100vw) - var(--uc-window-control-space)) !important;
     max-width: var(--tab-max-width) !important;
     margin-inline-start: calc(var(--tab-shadow-max-size) * -1) !important;
   }
-  .tabbrowser-tab[selected="true"][pinned="true"] {
+  .tabbrowser-tab[selected][pinned="true"] {
     flex: 100;
     -moz-box-flex: 100;
     max-width: var(--tab-max-width) !important;
   }
-  .tabbrowser-tab[selected="true"] .tab-label-container {
+  .tabbrowser-tab[selected] .tab-label-container {
     margin-inline: 0 !important;
   }
   .tab-content {
@@ -6871,8 +6871,8 @@
     width: 100%;
   }
   /* Pinned */
-  #tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected="true"],
-  #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected="true"] {
+  #tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected],
+  #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected] {
     position: relative !important;
   }
   #tabbrowser-tabs {
@@ -7797,13 +7797,13 @@
        FF v96+ replace by var(--lwt-tab-line-color) */
     background-color: var(--tab-line-color, var(--lwt-tab-line-color, rgb(10, 132, 255))) !important;
   }
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+  .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
     background-color: rgba(0, 0, 0, 0.2) !important;
     opacity: 1 !important;
     transform: none !important;
   }
   #TabsToolbar[brighttext]
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+    .tabbrowser-tab:hover:not([selected], [multiselected])
     > .tab-stack
     > .tab-background
     > .tab-context-line {
@@ -7819,12 +7819,12 @@
     stroke: var(--toolbar-color) !important;
   }
   /* Animation */
-  .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+  .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
     opacity: 0 !important;
     transform: scaleX(0) !important;
   }
   @media (prefers-reduced-motion: no-preference) {
-    .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+    .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
       transition: transform 250ms var(--animation-easing-function), opacity 250ms var(--animation-easing-function) !important; /* --animation-easing-function: cubic-bezier(.07, .95, 0, 1); */
     }
   }
@@ -7897,15 +7897,12 @@
       margin-right: 6px;
     }
     /* Set the hover effect */
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
-      > .tab-stack
-      > .tab-background
-      > .tab-context-line::before {
+    .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line::before {
       background-color: rgba(0, 0, 0, 0.4) !important;
       opacity: 1 !important;
     }
     #TabsToolbar[brighttext]
-      .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+      .tabbrowser-tab:hover:not([selected], [multiselected])
       > .tab-stack
       > .tab-background
       > .tab-context-line::before {
@@ -7913,7 +7910,7 @@
     }
     /* Animation */
     @media (prefers-reduced-motion: no-preference) {
-      .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+      .tabbrowser-tab:hover:not([selected], [multiselected])
         > .tab-stack
         > .tab-background
         > .tab-context-line::before {
@@ -8535,7 +8532,7 @@
     --tab-label-mask-size: 30%;
   }
   #tabbrowser-tabs[closebuttons="activetab"]
-    .tabbrowser-tab:is([visuallyselected], [multiselected="true"])
+    .tabbrowser-tab:is([visuallyselected], [multiselected])
     .tab-label-container {
     --tab-label-mask-size: 25%;
   }
@@ -16918,7 +16915,7 @@
 }
 @media (-moz-bool-pref: "userChrome.theme.fully_color") {
   :root:is(:-moz-lwtheme, [lwtheme]) #editBMPanel_folderTree > treechildren::-moz-tree-row(selected),
-  #editBMPanel_tagsSelector > richlistitem[selected="true"] {
+  #editBMPanel_tagsSelector > richlistitem[selected] {
     background-color: var(--button-active-bgcolor, color-mix(in srgb, currentColor 30%, transparent)) !important;
   }
 }
@@ -17681,8 +17678,8 @@
       color: var(--in-content-item-hover-text) !important;
       background-color: var(--in-content-item-hover) !important;
     }
-    xul|menulist > xul|menupopup > xul|menu:not([disabled="true"])[selected="true"],
-    xul|menulist > xul|menupopup > xul|menuitem:not([disabled="true"])[selected="true"] {
+    xul|menulist > xul|menupopup > xul|menu:not([disabled="true"])[selected],
+    xul|menulist > xul|menupopup > xul|menuitem:not([disabled="true"])[selected] {
       color: var(--in-content-item-selected-text) !important;
       background-color: var(--in-content-item-selected) !important;
     }
@@ -17821,7 +17818,7 @@
     }
     @media (-moz-bool-pref: "userChrome.theme.proton_chrome") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
       xul|menulist > xul|menupopup > xul|menuitem[checked="true"]::before,
-      xul|menulist > xul|menupopup > xul|menuitem[selected="true"]::before {
+      xul|menulist > xul|menupopup > xul|menuitem[selected]::before {
         display: none !important;
       }
       xul|menulist::part(dropmarker) {
@@ -17918,7 +17915,7 @@
     #viewGroup > radio:hover {
       background-color: var(--in-content-button-background-hover) !important; /* #E0E8F6; */
     }
-    #viewGroup > radio[selected="true"] {
+    #viewGroup > radio[selected] {
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }
@@ -18234,14 +18231,14 @@
       }
     }
     @media (-moz-bool-pref: "userChrome.theme.proton_chrome") and (-moz-gtk-csd-available) {
-      richlistitem[selected="true"],
+      richlistitem[selected],
       richlistitem:hover {
         background-color: var(--organizer-hover-background) !important;
         color: var(--organizer-color) !important;
       }
     }
     @media (-moz-bool-pref: "userChrome.theme.proton_chrome") and (-moz-gtk-csd-available) {
-      richlistbox:where(:focus) > richlistitem[selected="true"] {
+      richlistbox:where(:focus) > richlistitem[selected] {
         background-color: var(--organizer-selected-background) !important;
       }
     }
@@ -22132,26 +22129,26 @@
   #scrollbutton-down,
   .titlebar-spacer[type="pre-tabs"],
   spacer:is([part="overflow-start-indicator"], [part="overflow-end-indicator"]),
-  .tabbrowser-tab:not([selected="true"]),
-  .tabbrowser-tab[selected="true"] .tab-background,
-  .tabbrowser-tab[selected="true"] .tab-stack:is(::before, ::after),
-  .tabbrowser-tab[selected="true"] .tab-close-button,
+  .tabbrowser-tab:not([selected]),
+  .tabbrowser-tab[selected] .tab-background,
+  .tabbrowser-tab[selected] .tab-stack:is(::before, ::after),
+  .tabbrowser-tab[selected] .tab-close-button,
   #tabs-newtab-button {
     display: none !important;
   }
-  .tabbrowser-tab[selected="true"] {
+  .tabbrowser-tab[selected] {
     -moz-window-dragging: drag;
     --tab-max-width: 100vw;
     min-width: calc(var(--uc-tabbar-width, 100vw) - var(--uc-window-control-space)) !important;
     max-width: var(--tab-max-width) !important;
     margin-inline-start: calc(var(--tab-shadow-max-size) * -1) !important;
   }
-  .tabbrowser-tab[selected="true"][pinned="true"] {
+  .tabbrowser-tab[selected][pinned="true"] {
     flex: 100;
     -moz-box-flex: 100;
     max-width: var(--tab-max-width) !important;
   }
-  .tabbrowser-tab[selected="true"] .tab-label-container {
+  .tabbrowser-tab[selected] .tab-label-container {
     margin-inline: 0 !important;
   }
   .tab-content {
@@ -22159,8 +22156,8 @@
     width: 100%;
   }
   /* Pinned */
-  #tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected="true"],
-  #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected="true"] {
+  #tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected],
+  #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected] {
     position: relative !important;
   }
   #tabbrowser-tabs {
@@ -23206,13 +23203,13 @@
        FF v96+ replace by var(--lwt-tab-line-color) */
     background-color: var(--tab-line-color, var(--lwt-tab-line-color, rgb(10, 132, 255))) !important;
   }
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+  .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
     background-color: rgba(0, 0, 0, 0.2) !important;
     opacity: 1 !important;
     transform: none !important;
   }
   #TabsToolbar[brighttext]
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+    .tabbrowser-tab:hover:not([selected], [multiselected])
     > .tab-stack
     > .tab-background
     > .tab-context-line {
@@ -23228,7 +23225,7 @@
     stroke: var(--toolbar-color) !important;
   }
   /* Animation */
-  .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+  .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
     opacity: 0 !important;
     transform: scaleX(0) !important;
   }
@@ -23236,7 +23233,7 @@
   /* Container Tab */
 }
 @media (-moz-bool-pref: "userChrome.tab.photon_like_contextline") and (prefers-reduced-motion: no-preference) {
-  .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+  .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
     transition: transform 250ms var(--animation-easing-function), opacity 250ms var(--animation-easing-function) !important; /* --animation-easing-function: cubic-bezier(.07, .95, 0, 1); */
   }
 }
@@ -23311,15 +23308,12 @@
     margin-right: 6px;
   }
   /* Set the hover effect */
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
-    > .tab-stack
-    > .tab-background
-    > .tab-context-line::before {
+  .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line::before {
     background-color: rgba(0, 0, 0, 0.4) !important;
     opacity: 1 !important;
   }
   #TabsToolbar[brighttext]
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+    .tabbrowser-tab:hover:not([selected], [multiselected])
     > .tab-stack
     > .tab-background
     > .tab-context-line::before {
@@ -23332,10 +23326,7 @@
   /* Remove side's background color border */
 }
 @media (not (-moz-bool-pref: "userChrome.tab.photon_like_contextline")) and (-moz-bool-pref: "userChrome.tab.supernova_like_contextline") and (prefers-reduced-motion: no-preference) {
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
-    > .tab-stack
-    > .tab-background
-    > .tab-context-line::before {
+  .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line::before {
     animation: toWide 0.2s cubic-bezier(0, 0.9, 0.15, 1);
   }
 }
@@ -23983,7 +23974,7 @@
     --tab-label-mask-size: 30%;
   }
   #tabbrowser-tabs[closebuttons="activetab"]
-    .tabbrowser-tab:is([visuallyselected], [multiselected="true"])
+    .tabbrowser-tab:is([visuallyselected], [multiselected])
     .tab-label-container {
     --tab-label-mask-size: 25%;
   }

--- a/css/leptonChromeESR.css
+++ b/css/leptonChromeESR.css
@@ -2417,7 +2417,7 @@
     background-color: var(--button-hover-bgcolor, color-mix(in srgb, currentColor 17%, transparent)) !important;
   }
   :root:is(:-moz-lwtheme, [lwtheme]) #editBMPanel_folderTree > treechildren::-moz-tree-row(selected),
-  #editBMPanel_tagsSelector > richlistitem[selected="true"] {
+  #editBMPanel_tagsSelector > richlistitem[selected] {
     background-color: var(--button-active-bgcolor, color-mix(in srgb, currentColor 30%, transparent)) !important;
   }
   #editBookmarkPanel #editBMPanel_namePicker,
@@ -3250,8 +3250,8 @@
       color: var(--in-content-item-hover-text) !important;
       background-color: var(--in-content-item-hover) !important;
     }
-    xul|menulist > xul|menupopup > xul|menu:not([disabled="true"])[selected="true"],
-    xul|menulist > xul|menupopup > xul|menuitem:not([disabled="true"])[selected="true"] {
+    xul|menulist > xul|menupopup > xul|menu:not([disabled="true"])[selected],
+    xul|menulist > xul|menupopup > xul|menuitem:not([disabled="true"])[selected] {
       color: var(--in-content-item-selected-text) !important;
       background-color: var(--in-content-item-selected) !important;
     }
@@ -3393,7 +3393,7 @@
     }
     @supports -moz-bool-pref("layout.css.osx-font-smoothing.enabled") {
       xul|menulist > xul|menupopup > xul|menuitem[checked="true"]::before,
-      xul|menulist > xul|menupopup > xul|menuitem[selected="true"]::before {
+      xul|menulist > xul|menupopup > xul|menuitem[selected]::before {
         display: none !important;
       }
       xul|menulist::part(dropmarker) {
@@ -3490,7 +3490,7 @@
     #viewGroup > radio:hover {
       background-color: var(--in-content-button-background-hover) !important; /* #E0E8F6; */
     }
-    #viewGroup > radio[selected="true"] {
+    #viewGroup > radio[selected] {
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }
@@ -3776,12 +3776,12 @@
       #clearDownloadsButton:focus-visible {
         outline: 2px solid var(--organizer-outline-color) !important;
       }
-      richlistitem[selected="true"],
+      richlistitem[selected],
       richlistitem:hover {
         background-color: var(--organizer-hover-background) !important;
         color: var(--organizer-color) !important;
       }
-      richlistbox:where(:focus) > richlistitem[selected="true"] {
+      richlistbox:where(:focus) > richlistitem[selected] {
         background-color: var(--organizer-selected-background) !important;
       }
       /*- Tree -----------------------------------------------------------------*/
@@ -7282,26 +7282,26 @@
   #scrollbutton-down,
   .titlebar-spacer[type="pre-tabs"],
   spacer:is([part="overflow-start-indicator"], [part="overflow-end-indicator"]),
-  .tabbrowser-tab:not([selected="true"]),
-  .tabbrowser-tab[selected="true"] .tab-background,
-  .tabbrowser-tab[selected="true"] .tab-stack:is(::before, ::after),
-  .tabbrowser-tab[selected="true"] .tab-close-button,
+  .tabbrowser-tab:not([selected]),
+  .tabbrowser-tab[selected] .tab-background,
+  .tabbrowser-tab[selected] .tab-stack:is(::before, ::after),
+  .tabbrowser-tab[selected] .tab-close-button,
   #tabs-newtab-button {
     display: none !important;
   }
-  .tabbrowser-tab[selected="true"] {
+  .tabbrowser-tab[selected] {
     -moz-window-dragging: drag;
     --tab-max-width: 100vw;
     min-width: calc(var(--uc-tabbar-width, 100vw) - var(--uc-window-control-space)) !important;
     max-width: var(--tab-max-width) !important;
     margin-inline-start: calc(var(--tab-shadow-max-size) * -1) !important;
   }
-  .tabbrowser-tab[selected="true"][pinned="true"] {
+  .tabbrowser-tab[selected][pinned="true"] {
     flex: 100;
     -moz-box-flex: 100;
     max-width: var(--tab-max-width) !important;
   }
-  .tabbrowser-tab[selected="true"] .tab-label-container {
+  .tabbrowser-tab[selected] .tab-label-container {
     margin-inline: 0 !important;
   }
   .tab-content {
@@ -7309,8 +7309,8 @@
     width: 100%;
   }
   /* Pinned */
-  #tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected="true"],
-  #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected="true"] {
+  #tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected],
+  #tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected] {
     position: relative !important;
   }
   #tabbrowser-tabs {
@@ -8241,13 +8241,13 @@
        FF v96+ replace by var(--lwt-tab-line-color) */
     background-color: var(--tab-line-color, var(--lwt-tab-line-color, rgb(10, 132, 255))) !important;
   }
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+  .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
     background-color: rgba(0, 0, 0, 0.2) !important;
     opacity: 1 !important;
     transform: none !important;
   }
   #TabsToolbar[brighttext]
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+    .tabbrowser-tab:hover:not([selected], [multiselected])
     > .tab-stack
     > .tab-background
     > .tab-context-line {
@@ -8263,12 +8263,12 @@
     stroke: var(--toolbar-color) !important;
   }
   /* Animation */
-  .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+  .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
     opacity: 0 !important;
     transform: scaleX(0) !important;
   }
   @media (prefers-reduced-motion: no-preference) {
-    .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+    .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
       transition: transform 250ms var(--animation-easing-function), opacity 250ms var(--animation-easing-function) !important; /* --animation-easing-function: cubic-bezier(.07, .95, 0, 1); */
     }
   }
@@ -8341,15 +8341,12 @@
       margin-right: 6px;
     }
     /* Set the hover effect */
-    .tabbrowser-tab:hover:not([selected="true"], [multiselected])
-      > .tab-stack
-      > .tab-background
-      > .tab-context-line::before {
+    .tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line::before {
       background-color: rgba(0, 0, 0, 0.4) !important;
       opacity: 1 !important;
     }
     #TabsToolbar[brighttext]
-      .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+      .tabbrowser-tab:hover:not([selected], [multiselected])
       > .tab-stack
       > .tab-background
       > .tab-context-line::before {
@@ -8357,7 +8354,7 @@
     }
     /* Animation */
     @media (prefers-reduced-motion: no-preference) {
-      .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+      .tabbrowser-tab:hover:not([selected], [multiselected])
         > .tab-stack
         > .tab-background
         > .tab-context-line::before {
@@ -8995,7 +8992,7 @@
     --tab-label-mask-size: 30%;
   }
   #tabbrowser-tabs[closebuttons="activetab"]
-    .tabbrowser-tab:is([visuallyselected], [multiselected="true"])
+    .tabbrowser-tab:is([visuallyselected], [multiselected])
     .tab-label-container {
     --tab-label-mask-size: 25%;
   }

--- a/css/leptonContent.css
+++ b/css/leptonContent.css
@@ -2259,15 +2259,15 @@
       background-color: var(--in-content-item-hover);
       color: var(--in-content-item-hover-text);
     }
-    :is(.contentPane, .main-content, #certmanagertabs) richlistbox > richlistitem[selected="true"],
-    #translations-manage-install-list > .translations-manage-language[selected="true"] {
+    :is(.contentPane, .main-content, #certmanagertabs) richlistbox > richlistitem[selected],
+    #translations-manage-install-list > .translations-manage-language[selected] {
       background-color: var(--in-content-item-selected);
       color: var(--in-content-item-selected-text);
     }
     :is(.contentPane, .main-content, #certmanagertabs)
       richlistbox
-      > richlistitem:nth-child(even):not([selected="true"], :hover),
-    #translations-manage-install-list > .translations-manage-language:nth-child(even):not([selected="true"], :hover) {
+      > richlistitem:nth-child(even):not([selected], :hover),
+    #translations-manage-install-list > .translations-manage-language:nth-child(even):not([selected], :hover) {
       background-color: var(--in-content-box-background-odd);
     }
   }
@@ -2678,12 +2678,12 @@
         #clearDownloadsButton:focus-visible {
           outline: 2px solid var(--organizer-outline-color) !important;
         }
-        richlistitem[selected="true"],
+        richlistitem[selected],
         richlistitem:hover {
           background-color: var(--organizer-hover-background) !important;
           color: var(--organizer-color) !important;
         }
-        richlistbox:where(:focus) > richlistitem[selected="true"] {
+        richlistbox:where(:focus) > richlistitem[selected] {
           background-color: var(--organizer-selected-background) !important;
         }
         /*- Tree -----------------------------------------------------------------*/
@@ -6029,15 +6029,15 @@
       background-color: var(--in-content-item-hover);
       color: var(--in-content-item-hover-text);
     }
-    :is(.contentPane, .main-content, #certmanagertabs) richlistbox > richlistitem[selected="true"],
-    #translations-manage-install-list > .translations-manage-language[selected="true"] {
+    :is(.contentPane, .main-content, #certmanagertabs) richlistbox > richlistitem[selected],
+    #translations-manage-install-list > .translations-manage-language[selected] {
       background-color: var(--in-content-item-selected);
       color: var(--in-content-item-selected-text);
     }
     :is(.contentPane, .main-content, #certmanagertabs)
       richlistbox
-      > richlistitem:nth-child(even):not([selected="true"], :hover),
-    #translations-manage-install-list > .translations-manage-language:nth-child(even):not([selected="true"], :hover) {
+      > richlistitem:nth-child(even):not([selected], :hover),
+    #translations-manage-install-list > .translations-manage-language:nth-child(even):not([selected], :hover) {
       background-color: var(--in-content-box-background-odd);
     }
   }
@@ -6491,14 +6491,14 @@
       }
     }
     @media (-moz-bool-pref: "userContent.page.proton") and (-moz-gtk-csd-available) and (-moz-bool-pref: "userContent.page.proton") {
-      richlistitem[selected="true"],
+      richlistitem[selected],
       richlistitem:hover {
         background-color: var(--organizer-hover-background) !important;
         color: var(--organizer-color) !important;
       }
     }
     @media (-moz-bool-pref: "userContent.page.proton") and (-moz-gtk-csd-available) and (-moz-bool-pref: "userContent.page.proton") {
-      richlistbox:where(:focus) > richlistitem[selected="true"] {
+      richlistbox:where(:focus) > richlistitem[selected] {
         background-color: var(--organizer-selected-background) !important;
       }
     }

--- a/css/leptonContentESR.css
+++ b/css/leptonContentESR.css
@@ -2262,15 +2262,15 @@
       background-color: var(--in-content-item-hover);
       color: var(--in-content-item-hover-text);
     }
-    :is(.contentPane, .main-content, #certmanagertabs) richlistbox > richlistitem[selected="true"],
-    #translations-manage-install-list > .translations-manage-language[selected="true"] {
+    :is(.contentPane, .main-content, #certmanagertabs) richlistbox > richlistitem[selected],
+    #translations-manage-install-list > .translations-manage-language[selected] {
       background-color: var(--in-content-item-selected);
       color: var(--in-content-item-selected-text);
     }
     :is(.contentPane, .main-content, #certmanagertabs)
       richlistbox
-      > richlistitem:nth-child(even):not([selected="true"], :hover),
-    #translations-manage-install-list > .translations-manage-language:nth-child(even):not([selected="true"], :hover) {
+      > richlistitem:nth-child(even):not([selected], :hover),
+    #translations-manage-install-list > .translations-manage-language:nth-child(even):not([selected], :hover) {
       background-color: var(--in-content-box-background-odd);
     }
   }
@@ -2681,12 +2681,12 @@
         #clearDownloadsButton:focus-visible {
           outline: 2px solid var(--organizer-outline-color) !important;
         }
-        richlistitem[selected="true"],
+        richlistitem[selected],
         richlistitem:hover {
           background-color: var(--organizer-hover-background) !important;
           color: var(--organizer-color) !important;
         }
-        richlistbox:where(:focus) > richlistitem[selected="true"] {
+        richlistbox:where(:focus) > richlistitem[selected] {
           background-color: var(--organizer-selected-background) !important;
         }
         /*- Tree -----------------------------------------------------------------*/

--- a/src/contents/proton_contents/_about_preferences.scss
+++ b/src/contents/proton_contents/_about_preferences.scss
@@ -14,11 +14,11 @@
       background-color: var(--in-content-item-hover);
       color: var(--in-content-item-hover-text);
     }
-    &[selected="true"] {
+    &[selected] {
       background-color: var(--in-content-item-selected);
       color: var(--in-content-item-selected-text);
     }
-    &:nth-child(even):not([selected="true"], :hover) {
+    &:nth-child(even):not([selected], :hover) {
       background-color: var(--in-content-box-background-odd);
     }
   }

--- a/src/library/_proton.scss
+++ b/src/library/_proton.scss
@@ -189,13 +189,13 @@
   outline: 2px solid var(--organizer-outline-color) !important;
 }
 
-richlistitem[selected="true"],
+richlistitem[selected],
 richlistitem:hover {
   background-color: var(--organizer-hover-background) !important;
   color: var(--organizer-color) !important;
 }
 
-richlistbox:where(:focus) > richlistitem[selected="true"] {
+richlistbox:where(:focus) > richlistitem[selected] {
   background-color: var(--organizer-selected-background) !important;
 }
 

--- a/src/tab/clipped_tab/_letters_cleary.scss
+++ b/src/tab/clipped_tab/_letters_cleary.scss
@@ -24,7 +24,7 @@
   .tab-label-container {
     --tab-label-mask-size: 30%;
   }
-  &:is([visuallyselected], [multiselected="true"]) .tab-label-container {
+  &:is([visuallyselected], [multiselected]) .tab-label-container {
     --tab-label-mask-size: 25%;
   }
 }

--- a/src/tab/selected_tab/_photon_like_contextline.scss
+++ b/src/tab/selected_tab/_photon_like_contextline.scss
@@ -17,13 +17,13 @@
   background-color: var(--tab-line-color, var(--lwt-tab-line-color, rgb(10, 132, 255))) !important;
 }
 
-.tabbrowser-tab:hover:not([selected="true"], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
+.tabbrowser-tab:hover:not([selected], [multiselected]) > .tab-stack > .tab-background > .tab-context-line {
   background-color: rgba(0, 0, 0, 0.2) !important;
   opacity: 1 !important;
   transform: none !important;
 }
 #TabsToolbar[brighttext]
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+  .tabbrowser-tab:hover:not([selected], [multiselected])
   > .tab-stack
   > .tab-background
   > .tab-context-line {
@@ -41,12 +41,12 @@
 }
 
 /* Animation */
-.tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+.tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
   opacity: 0 !important;
   transform: scaleX(0) !important;
 }
 @media (prefers-reduced-motion: no-preference) {
-  .tabbrowser-tab:not([selected="true"], [multiselected]) .tab-context-line {
+  .tabbrowser-tab:not([selected], [multiselected]) .tab-context-line {
     transition: transform 250ms var(--animation-easing-function), opacity 250ms var(--animation-easing-function) !important; /* --animation-easing-function: cubic-bezier(.07, .95, 0, 1); */
   }
 }

--- a/src/tab/selected_tab/_supernova_like_contextline.scss
+++ b/src/tab/selected_tab/_supernova_like_contextline.scss
@@ -35,7 +35,7 @@ tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-con
 }
 
 /* Set the hover effect */
-.tabbrowser-tab:hover:not([selected="true"], [multiselected])
+.tabbrowser-tab:hover:not([selected], [multiselected])
   > .tab-stack
   > .tab-background
   > .tab-context-line::before {
@@ -44,7 +44,7 @@ tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-con
 }
 
 #TabsToolbar[brighttext]
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+  .tabbrowser-tab:hover:not([selected], [multiselected])
   > .tab-stack
   > .tab-background
   > .tab-context-line::before {
@@ -54,7 +54,7 @@ tabs tab.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-con
 
 /* Animation */
 @media (prefers-reduced-motion: no-preference) {
-  .tabbrowser-tab:hover:not([selected="true"], [multiselected])
+  .tabbrowser-tab:hover:not([selected], [multiselected])
     > .tab-stack
     > .tab-background
     > .tab-context-line::before {

--- a/src/tabbar/_as_titlebar.scss
+++ b/src/tabbar/_as_titlebar.scss
@@ -17,15 +17,15 @@
 #scrollbutton-down,
 .titlebar-spacer[type="pre-tabs"],
 spacer:is([part="overflow-start-indicator"], [part="overflow-end-indicator"]),
-.tabbrowser-tab:not([selected="true"]),
-.tabbrowser-tab[selected="true"] .tab-background,
-.tabbrowser-tab[selected="true"] .tab-stack:is(::before, ::after),
-.tabbrowser-tab[selected="true"] .tab-close-button,
+.tabbrowser-tab:not([selected]),
+.tabbrowser-tab[selected] .tab-background,
+.tabbrowser-tab[selected] .tab-stack:is(::before, ::after),
+.tabbrowser-tab[selected] .tab-close-button,
 #tabs-newtab-button {
   display: none !important;
 }
 
-.tabbrowser-tab[selected="true"] {
+.tabbrowser-tab[selected] {
   -moz-window-dragging: drag;
   --tab-max-width: 100vw;
   min-width: calc(var(--uc-tabbar-width, 100vw) - var(--uc-window-control-space)) !important;
@@ -48,8 +48,8 @@ spacer:is([part="overflow-start-indicator"], [part="overflow-end-indicator"]),
 }
 
 /* Pinned */
-#tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected="true"],
-#tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected="true"] {
+#tabbrowser-tabs[positionpinnedtabs] > #pinned-tabs-container > .tabbrowser-tab[pinned][selected],
+#tabbrowser-tabs[positionpinnedtabs] > #tabbrowser-arrowscrollbox > .tabbrowser-tab[pinned][selected] {
   position: relative !important;
 }
 #tabbrowser-tabs {

--- a/src/theme/_fully_color.scss
+++ b/src/theme/_fully_color.scss
@@ -180,7 +180,7 @@ html|button.ghost-button:not(.semi-transparent):enabled:hover:active {
   background-color: var(--button-hover-bgcolor, color-mix(in srgb, currentColor 17%, transparent)) !important;
 }
 :root#{$lwtheme} #editBMPanel_folderTree > treechildren::-moz-tree-row(selected),
-#editBMPanel_tagsSelector > richlistitem[selected="true"] {
+#editBMPanel_tagsSelector > richlistitem[selected] {
   background-color: var(--button-active-bgcolor, color-mix(in srgb, currentColor 30%, transparent)) !important;
 }
 

--- a/src/theme/proton_chrome/_page_info.scss
+++ b/src/theme/proton_chrome/_page_info.scss
@@ -29,7 +29,7 @@
     &:hover {
       background-color: var(--in-content-button-background-hover) !important; /* #E0E8F6; */
     }
-    &[selected="true"] {
+    &[selected] {
       color: var(--in-content-button-text-color) !important; /* SelectedItemText */
       background-color: var(--in-content-button-background-active) !important; /* #C1D2EE; */
     }

--- a/src/theme/proton_chrome/_proton_commons.scss
+++ b/src/theme/proton_chrome/_proton_commons.scss
@@ -337,7 +337,7 @@
       color: var(--in-content-item-hover-text) !important;
       background-color: var(--in-content-item-hover) !important;
     }
-    &:not([disabled="true"])[selected="true"] {
+    &:not([disabled="true"])[selected] {
       color: var(--in-content-item-selected-text) !important;
       background-color: var(--in-content-item-selected) !important;
     }
@@ -496,7 +496,7 @@
 
   @include OS($mac) {
     xul|menulist > xul|menupopup > xul|menuitem[checked="true"]::before,
-    xul|menulist > xul|menupopup > xul|menuitem[selected="true"]::before {
+    xul|menulist > xul|menupopup > xul|menuitem[selected]::before {
       display: none !important;
     }
 


### PR DESCRIPTION
**Describe the PR**
This PR restores the accent-coloured line above the selected browser tab by changing `[selected="true"]` to `[selected]`. Since Firefox appears to have stopped supporting the former syntax, this probably fixes other issues as well.

This is part of the fix for #1191. In order to restore the tab background colour, it is also necessary to cherry-pick https://github.com/black7375/Firefox-UI-Fix/commit/72be27cd07e7ae3d5e719ffa6e4a0b96d45e0fad from master to photon-style. I have not done that in this PR because I do not know whether that will interfere with the way you organise releases.

**PR Type**
<!-- Check like `- [x]`. -->

- [ ] `Add:` Add feature or enhanced.
- [x] `Fix:` Bug fix or change default values.
- [ ] `Clean:` Refactoring.
- [ ] `Doc:` Update docs.

**Related Issue**
#1191